### PR TITLE
Add third-party-check to avoid merge conflict warnings

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -114,3 +114,42 @@
       sqlreporter:
     failure:
       sqlreporter:
+
+- pipeline:
+    name: third-party-check
+    description: |
+      Newly uploaded patchsets to projects that are external to OpenStack
+      enter this pipeline to receive an initial +/-1 Verified vote.
+    success-message: Build succeeded (third-party-check pipeline).
+    # TODO(mordred) We should write a document for non-OpenStack developers
+    failure-message: |
+      Build failed (third-party-check pipeline) integration testing with
+      OpenStack. For information on how to proceed, see
+      http://docs.openstack.org/infra/manual/developers.html#automated-testing
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s*$
+    start:
+      github.com:
+        status: 'pending'
+        status-url: 'https://ansible.softwarefactory-project.io/zuul/status.html'
+        comment: false
+    success:
+      github:
+        status: 'success'
+      sqlreporter:
+    failure:
+      github:
+        status: 'failure'
+      sqlreporter:
+    # Don't report merge-failures to github
+    merge-failure:
+        sqlreporter:


### PR DESCRIPTION
Based on Monty Taylor (mordred) Zuul configuration.

Avoid sf-bot *and* ansibullbot both informing about merge conflicts.