### PR TITLE
Link to results from GH Status box

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -149,10 +149,12 @@
     success:
       github.com:
         status: 'success'
+        comment: false
       sqlreporter:
     failure:
       github.com:
         status: 'failure'
+        comment: false
       sqlreporter:
     # Don't report merge-failures to github
     merge-failure:

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -23,6 +23,7 @@
     success:
       github.com:
         status: 'success'
+        status-url: 'https://ansible.softwarefactory-project.io/'
         comment: false
       sqlreporter:
     failure:

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -23,10 +23,12 @@
     success:
       github.com:
         status: 'success'
+        comment: false
       sqlreporter:
     failure:
       github.com:
         status: 'failure'
+        comment: false
       sqlreporter:
 
 - pipeline:


### PR DESCRIPTION
Not sure what the variables are that represent

`https://ansible.softwarefactory-project.io/logs/4/4/f5c6eca18c78cda01c9432e88b66dbde8a33aece/check/ansible-test-network-integration-vyos-py2/195a67f/`

Guessing something like
`https://ansible.softwarefactory-project.io/logs/4/4/{buildset.uuid}/{pipeline.name}/ansible-test-network-integration-vyos-py2/{change.number}/`

Though setting `status-url` doesn't seem to take effect