### PR TITLE
Create base-minimal / base-minimal-test jobs

### DIFF
--- a/playbooks/base-minimal-test/post.yaml
+++ b/playbooks/base-minimal-test/post.yaml
@@ -1,0 +1,22 @@
+---
+- hosts: localhost
+  roles:
+    - role: add-fileserver
+      fileserver: "{{ site_ansiblelogs }}"
+    - emit-ara-html
+
+- hosts: "{{ site_ansiblelogs.fqdn }}"
+  tasks:
+    # Use a block because play vars doesn't take precedence on roles vars
+    - block:
+        - import_role: name=upload-logs
+      vars:
+        zuul_log_url: "{{ site_ansiblelogs.url }}"
+        zuul_logserver_root: "{{ site_ansiblelogs.path }}"
+
+- hosts: localhost
+  ignore_errors: yes
+  roles:
+    - role: submit-logstash-jobs
+      logstash_gearman_server: "ansible.softwarefactory-project.io"
+      logstash_gearman_server_port: 4731

--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  roles:
+    - prepare-workspace
+    - role: validate-host

--- a/playbooks/base-minimal/post.yaml
+++ b/playbooks/base-minimal/post.yaml
@@ -1,0 +1,22 @@
+---
+- hosts: localhost
+  roles:
+    - role: add-fileserver
+      fileserver: "{{ site_ansiblelogs }}"
+    - emit-ara-html
+
+- hosts: "{{ site_ansiblelogs.fqdn }}"
+  tasks:
+    # Use a block because play vars doesn't take precedence on roles vars
+    - block:
+        - import_role: name=upload-logs
+      vars:
+        zuul_log_url: "{{ site_ansiblelogs.url }}"
+        zuul_logserver_root: "{{ site_ansiblelogs.path }}"
+
+- hosts: localhost
+  ignore_errors: yes
+  roles:
+    - role: submit-logstash-jobs
+      logstash_gearman_server: "ansible.softwarefactory-project.io"
+      logstash_gearman_server_port: 4731

--- a/playbooks/base-minimal/pre.yaml
+++ b/playbooks/base-minimal/pre.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  roles:
+    - prepare-workspace
+    - role: validate-host

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -37,24 +37,3 @@
       nodes:
         - name: container
           label: runc-fedora
-
-- job:
-    name: base-test
-    parent: null
-    description: |
-      A job to test changes to the base job without disturbing the
-      main job in production.  Not for general use.
-    pre-run: playbooks/base-test/pre.yaml
-    post-run:
-      - playbooks/base-test/post.yaml
-    roles:
-      - zuul: sf-jobs
-      - zuul: openstack-infra/zuul-jobs
-    timeout: 1800
-    attempts: 3
-    secrets:
-      - site_ansiblelogs
-    nodeset:
-      nodes:
-        - name: container
-          label: runc-fedora

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -37,3 +37,44 @@
       nodes:
         - name: container
           label: runc-fedora
+
+- job:
+    name: base-minimal
+    parent: null
+    description: |
+      The base-minimal job for Ansible's installation of Zuul.
+    pre-run: playbooks/base-minimal/pre.yaml
+    post-run:
+      - playbooks/base-minimal/post.yaml
+    roles:
+      - zuul: sf-jobs
+      - zuul: openstack-infra/zuul-jobs
+    timeout: 1800
+    attempts: 3
+    secrets:
+      - site_ansiblelogs
+    nodeset:
+      nodes:
+        - name: container
+          label: runc-fedora
+
+- job:
+    name: base-minimal-test
+    parent: null
+    description: |
+      A job to test changes to the base-minimal job without disturbing the
+      main job in production.  Not for general use.
+    pre-run: playbooks/base-minimal-test/pre.yaml
+    post-run:
+      - playbooks/base-minimal-test/post.yaml
+    roles:
+      - zuul: sf-jobs
+      - zuul: openstack-infra/zuul-jobs
+    timeout: 1800
+    attempts: 3
+    secrets:
+      - site_ansiblelogs
+    nodeset:
+      nodes:
+        - name: container
+          label: runc-fedora


### PR DESCRIPTION
These jobs are not used at the moment, but will be once we re-parent base to them.  The goal here is to move base into ansible-zuul-jobs allow for users to propose speculative changes to them. 