### PR TITLE
secret: fix known host to use the same key

### DIFF
--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -5,7 +5,7 @@
       url: http://ansible.softwarefactory-project.io/logs
       fqdn: ansible.softwarefactory-project.io
       path: /var/www/logs
-      ssh_known_hosts: ansible.softwarefactory-project.io ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKrzCDrUdGBvF+AYDoUXu+Q9EHumKsJG+Df6tvdIBWu0PmBy0Vpaaz/D8IslsGwJDqszNNzTTsue9C2Ppg+7VQ8=
+      ssh_known_hosts: ansible.softwarefactory-project.io ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDyMleCpbfaL6aLInD+VhcB2NeXEDxMrCASKlJsN0ZHZAFkMjPeljw1dnN15AGL4HGgSlJeGXLwq1Gb6VMhI4ghHwFpEiU3bPW8nGDQtaZhnzC506+DLQiWLxA+KXGeKOUPt+l7f/nHItaIjVfTH3K1d3u8w9OLdO2dACIk19yRJ1bNPxLCSG+UpIb0ui0SCHZRb4LTaNx3d5lGDLpVJpVSsG5VcE0JIYy/hyH2QiMO8y9wu2l+JHA2C3wbS5Cv8GUzi37ZD1zA9r8SeD1eLoMMEUcCkkg6B4c7AqqrqGKoJdIhB7BkOnhY/PixUomNo2cvp+LmpmzCz4H9gqLi0d99
       ssh_username: loguser
       ssh_private_key: !encrypted/pkcs1-oaep
         - BU2ay4Q71JQh3z/UZyd5MpDGZfWIKDZQQjzejpzpyTnT9pnW3GQ4hSeOK+DjsCAZutPB4


### PR DESCRIPTION
It seems like config-update job is failing because two secrets
define different key format for the same host.
This change should fix config-update POST_FAILURE errors.