### PR TITLE
Secrets: Provide encrypted keys w/o \n

### DIFF
--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -167,24 +167,24 @@
     data:
       user: awx-public-ci-files-user
       secret_access_key: !encrypted/pkcs1-oaep
-        - P3UW9X7pai+jCeZl2dQJTgr52+0XMb6emZFLOz2FZr8ffJFNzl3ig1hDH2277wIWySXXZ
-          sJsWom7g05AjB/yQi9Nl075Z08tpOsOHz2eKOp4/mDaODVJy+fuAscB/CIXBgKc5p3P9k
-          Uqc/xpohkg20sHjYnloFqMYVA/xEl/GAItWvj6EhjChmdyZMpsjwt7mAqi4bGBYGy8IQI
-          mSN3cw4oe8VRC8GDjTdsVYxTZk6Y8tKGdMXgd+Lc6cnQxkjII0emw0UELfjRCYUbWV9BM
-          BvJVx/0TyXiLL7KDac5uPh2/VpfiuRyztBcDo5Q7M+8ADPq9g8PPkyAM60+8rpIbJMMfo
-          ihIduqqCztjHGKFMZPXBNb3N0fod8IE0rP25w2ouyk+IhNRv4nNPk4LlA1CxtAuib+bq7
-          xqDfgtnKqZF2W99WtHMZq0me77Y2bmFsR00mOAr23GqUQTjEXef1x11kqyrhbjVjHcZyQ
-          XYHonL4gXIaG8kJMs7L4zQotWsxCuZlU4QqPyNFUtbtIIgCLK6q5N1L/wt8Bn9TVfV3oB
-          8jCVos16tv9L+iaaeDUmqk2VnR4CvMs1MCl1o0jhHwewm1xlKrm+8TeLTeQvSAzUhWtuq
-          Kb3pJzQYdvsMGxCZhHdZ/IMhnF/DjHiaM5/7hdG5TdV18Mk1JIBsJMdSTHf5ao=
+        - hCmO7BQQugI/EpD4faY/7CXLm08XVgufeNpuatKi36h66W3aGfcaM4yLmyVncY5O1hOu1
+          u96pgmm8R9VVqsFXqUCv2GGBEbbZL227xhzcFywX4cJHUeFzAtdVBmTg27jqJFSr9GpVR
+          ldvrux/RQPIoKB6l0zkVSV+NVULdE2xS5iQdfUbXj4K8FoXY9fhPbshBwpgPIWmorXuKR
+          JOEc9x8WTu5/AaQOE9r74+98VGFyssGLFHPXAPcBZAf9wyDCkEv/hI9xFpjzDVZVsq+nh
+          usEpEbgn5KvLRHgz1P2740I02n0aYM1QJBuGDKgfCGJOjLXp+opN5g69CeI8b5TEwuSLM
+          dGfU/SBt4O/HNfOT02BTMQSQgfCIs8MUo2qlYkHxlE6vdrCEmkuJ2vPfqOTGfU8WhcJXQ
+          bDiwbgb9vG4Ve8mFpUzT3yDA/FGSxLxgBpJjfNuLhzpUulDNudD2WdOjf0nVv+pm/qkZo
+          wUAx1uhy0+EObKD6Uyn4YAtU3DbXnLjRaYLxKpxi1BuP1RdUElgqN8i50fjXOIFcnQvla
+          5kQuRKk/359tzDT3pioekdTHRxIRtZsJF+tdgr20O5VXgbalU3YeSwo/f0S37qgRFkxqH
+          muWwEdoNYt/jQtY7bSDvR+rf/JGschB5ZFjQDnKd7qA5kM4RUyennQniZd2w00=
       access_key_id: !encrypted/pkcs1-oaep
-        - iHxYK8gF0j+E17JNFpzJPJE/ClYh1mCveWu5CfbQu0mZlfmc6tQ10RsfdUl7bhtGtiMkr
-          A6n0nuyN1Av+Em/vsGl+dp0EMMit7sdsnimQXLPtByct39bXOO4qQFQYfjufX8Epx7wjN
-          YBpkk2F9BE9vL75FJ/to96J+QXutMUJTEMlFdQXkzmeppxRApm68n5gyfi9XlIywMUr+K
-          LaHhqFl6vM7M+UbD8x28iASrskPsU/XhK+qUi2XOu4c1Uz9pzO6i54oB7cb5isg7AT9IC
-          RrSNHcOfKVUwOOi5kAUnqgoRSWQot5WPCxUUTHCanQfCDlmL9zMTz+j/6Tbv9D5z9xWr2
-          GISjDH2yZYH8Y7/Zx03QrnFIYamR+25NVzBhnwqpePh4250MbbIcbk3ALnBhhXep4Gy83
-          GukIdXyml9/qJzpRXSdEyLp63M2rilVkH/WRHq/pR2vxVItd7AP0wyIBPlaJLyz9tggjP
-          zPswbZ+r1manGDgI7ZW0Qf5QqzUF93AKiTmrid5iTrcncVskm2itCdxymJfWUIIfx2Px6
-          +vFB0JqE/Uh4aUlK9ibgyA4/sNCheKu1hvgBFQM3zHtfGI/YQk849SDnOCU5F5gSvipke
-          N8+n1v3i4GSauH5TM9S8I8i4C0qdKoPpElTgH5EmaBMYDOYNG2Ubz9/cbkxVkU=
+        - IkyZ0cdzX/ceqr8G4fQ7vXM6S9qqAwg+mDkGsmr/oV9Pi4/M/h73mSaJqUnyBu0ns8gu1
+          +7qkDioL+UvutNqpfTqLtKWArVCP7PDIYCsHSsQbZzWRFQttsu4TQJfRJhh42p8xJcpgI
+          12xVdJ8jXsTDVD7tixF9vOdurld9C5Allab+KQO1AeMwhMdK8pcq32JXIJjklsMgDDFso
+          MF7JWMR4YzfiLE1MzJq9qAzfyH5h5bOngtWSPqjz2Jgwq8d/MV/uZ3q2L745eAqug9EFP
+          tVkqWTQW95YM4Ux1KPYrQ780tD0kHRzW/32MIxAiij/vNjXB8xT7gnQfdpo23aq1fnCJs
+          81g5jga7kxQrwT21mT5nx4cFDpky7K7301Azg4T3DT9WyKOYv2L11vt7/FDnc9kBRAVXa
+          PavXjUGBd0CP4WgahSR2w1ao5iviLNf/zOQS32nzcRu+whwk6qEmtfSvG81zbogsSuhDs
+          JVmcbQn0sPV0uNCbxSEFPc1/SKgXgpcxHbhqW+MfkExyGTC/UHHz+7l+u8lodurDK1uPc
+          Gr8YQ+PJyY0bAsz0xIqGtgkP5NuTz2kWKqlAYDbf9G74ropU/MMAiWvYUr5AXlp1ofcyE
+          1q2zhuq1M5nCjl8BfTNvQJc9NCkb/RMiWCvr5SnJOWmX4NUN+0J6cEiqlcMY9M=


### PR DESCRIPTION
The keys that were provided were encrypted with a \n in the file (vim
default) This lead to the access key being "access_key\n" which is not a
valid access_key.

Newly generated content have been generated with a vim file configured
to not have a \n (:set noeol, :set binary) the content of the access key
should be correct now.