### PR TITLE
zuul-config: exclude unprotect branch

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -6,7 +6,8 @@ resources:
       source-repositories:
         # The config projects
         - ansible/zuul-config:
-            zuul/config-project: True
+            zuul/config-project: true
+            zuul/exclude-unprotected-branches: true
 
         # Shared jobs
         - ansible/zuul-jobs


### PR DESCRIPTION
Now that the master branch is protected, there is no need to
include unprotected branches. This change also mitigate a
recent issue with github api response, see:
https://review.openstack.org/633314