### PR TITLE
Exclude unprotected branches for ansible/zuul-config

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -7,6 +7,7 @@ resources:
         # The config projects
         - ansible/zuul-config:
             zuul/config-project: True
+            zuul/exclude-unprotected-branches: true
 
         # Shared jobs
         - ansible/zuul-jobs


### PR DESCRIPTION
We should keep zuul-config branches, since it is a config-project, it
would be possible to merge code into another branch, and break zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>