### PR TITLE
Remove ansible/ansible-runner jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -19,8 +19,3 @@
               - tox-awx-api
               - tox-awx-ui
               - tox-awx-swagger
-
-- project:
-    name: ansible/ansible-runner
-    templates:
-      - python


### PR DESCRIPTION
We no longer want to run jobs on ansible/ansible-runner, as we are in
the process of moving the repo into zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>