### PR TITLE
Remove ansible/ansible-runner from zuul tenant configuration

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -17,5 +17,4 @@ resources:
             zuul/include: []
         - ansible/zuul-test-repo:
             zuul/exclude-unprotected-branches: true
-        - ansible/ansible-runner
         - ansible/awx


### PR DESCRIPTION
We have migrated this repo to zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>