### PR TITLE
Add playbook and role for running awx tests in k8s

### DIFF
--- a/playbooks/run_awx_tests.yml
+++ b/playbooks/run_awx_tests.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: run_awx_tests

--- a/roles/run_awx_tests/tasks/main.yml
+++ b/roles/run_awx_tests/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+- set_fact:
+    pod_name: "{{ zuul.job }}-{{ zuul.change }}"
+    image_tag: "awx-pr-{{ zuul.change }}"
+  when: pod_name is not defined
+
+- name: Clean up orphaned pods
+  shell: |
+    kubectl delete pod {{ pod_name }} --grace-period=1 --ignore-not-found
+
+- name: Pre-pull images
+  shell: |
+    docker pull gcr.io/ansible-tower-engineering/awx_devel:{{ zuul.branch }} | cat
+    docker pull gcr.io/ansible-tower-engineering/awx_devel:{{ image_tag }} | cat
+  ignore_errors: yes
+
+- name: Build image
+  shell: |
+    docker build -f tools/docker-compose/Dockerfile \
+      -t gcr.io/ansible-tower-engineering/awx_devel:{{ image_tag }} \
+      --cache-from gcr.io/ansible-tower-engineering/awx_devel:{{ image_tag }} \
+      --cache-from gcr.io/ansible-tower-engineering/awx_devel:{{ zuul.branch }} .
+  args:
+    chdir: "{{ ansible_env.HOME }}/{{ zuul.project.src_dir }}"
+
+- name: Push image
+  shell: |
+    docker push gcr.io/ansible-tower-engineering/awx_devel:{{ image_tag }} | cat
+
+- name: Create tmpfile for pod
+  tempfile:
+    suffix: ".pod.yml"
+  register: podtmpfile
+
+- name: Render podtmpfile
+  template:
+    src: pod.yml.j2
+    dest: "{{ podtmpfile.path }}"
+
+- name: Run and clean up the thing
+  block:
+    - name: Apply api objects
+      shell: |
+        kubectl apply -f {{ podtmpfile.path }}
+
+    - name: Wait for first init container to start
+      shell: |
+        kubectl -n default get pod {{ pod_name }} \
+          -o jsonpath="{.status.initContainerStatuses[0].state}"
+      register: result
+      until: result.stdout | regex_search('running|terminated')
+      delay: 5
+      retries: 25
+
+    - name: Tail logs for repo clone
+      shell: |
+        kubectl logs -f {{ pod_name }} -c clone-repo
+
+    - name: Wait for tests to start
+      shell: kubectl -n default get pod {{ pod_name }} -o jsonpath="{.status.phase}"
+      register: result
+      until: result.stdout in ['Running', 'Succeeded']
+      delay: 5
+      retries: 25
+
+    - name: Tail logs for tests
+      shell: |
+        kubectl logs -f {{ pod_name }}
+        exit $(kubectl get pod {{ pod_name }} \
+          -o jsonpath="{.status.containerStatuses[0].state.terminated.exitCode}")
+  always:
+    - name: Delete pod after successful run
+      shell: |
+        kubectl delete pod {{ pod_name }}
+

--- a/roles/run_awx_tests/templates/cloudbuild.yml.j2
+++ b/roles/run_awx_tests/templates/cloudbuild.yml.j2
@@ -1,0 +1,16 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker pull gcr.io/ansible-tower-engineering/awx_devel:{{ zuul.branch }} || exit 0
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+            'build',
+            '-f', './tools/docker-compose/Dockerfile',
+            '-t', 'gcr.io/ansible-tower-engineering/awx_devel:{{ pod_name }}',
+            '--cache-from', 'gcr.io/ansible-tower-engineering/awx_devel:{{ zuul.branch }}',
+            '.'
+          ]
+images: ['gcr.io/ansible-tower-engineering/awx_devel:{{ pod_name }}']

--- a/roles/run_awx_tests/templates/pod.yml.j2
+++ b/roles/run_awx_tests/templates/pod.yml.j2
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ pod_name }}"
+spec:
+  restartPolicy: Never
+  volumes:
+    - name: git-repo
+      emptyDir:
+        medium: Memory
+    - name: git-clone
+      configMap:
+        name: git-clone
+        defaultMode: 0755
+    - name: kaniko-secret
+      secret:
+        secretName: kaniko-secret
+  initContainers:
+    - name: clone-repo
+      image: alpine/git
+      command:
+        - /usr/local/git/git-clone.sh
+      volumeMounts:
+        - name: git-repo
+          mountPath: /awx_devel
+        - name: git-clone
+          mountPath: /usr/local/git
+      env:
+        - name: GIT_REF
+          value: {{ zuul.patchset | default('devel') }}
+  containers:
+    - name: api-tests
+      imagePullPolicy: Always
+      image: gcr.io/ansible-tower-engineering/awx_devel:{{ image_tag }}
+      workingDir: /awx_devel
+      command: {{ command | default([]) }}
+      args: {{ args | default([]) }}
+      volumeMounts:
+        - name: git-repo
+          mountPath: /awx_devel
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: git-clone
+data:
+  git-clone.sh: |
+    #!/bin/sh -xe
+    git init /awx_devel && cd /awx_devel
+    git fetch --tags --quiet https://github.com/ansible/awx.git +refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/*
+    git -c advice.detachedHead=false checkout -f ${GIT_REF}

--- a/zuul.d/awx-jobs.yaml
+++ b/zuul.d/awx-jobs.yaml
@@ -1,5 +1,11 @@
 ---
 - job:
+    name: awx-tests
+    run: playbooks/run_awx_tests.yml
+    nodeset: static-node
+    abstract: true
+
+- job:
     name: awx-push-new-schema
     run: playbooks/awx-push-new-schema.yaml
     allowed-projects:


### PR DESCRIPTION
I might need to iterate on this a couple times but since we dont have pre-merge testing on this repo ¯\_(ツ)_/¯

I’ve tested this in zuul-jobs and it works. Moving here inside of the config-project so it cant be attacked.