### PR TITLE
AWX: skip unprotected branch

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -15,4 +15,5 @@ resources:
         # Ansible projects
         - ansible/ansible:
             zuul/include: []
-        - ansible/awx
+        - ansible/awx:
+            zuul/exclude-unprotected-branches: true


### PR DESCRIPTION
This change should prevent MERGER_FAILURE caused by awx feature branch workflow
that may results in:

  ValueError: Could not parse git-remote prune result:
    ' refs/remotes/origin/HEAD will become dangling!'