### PR TITLE
Use double quotes to avoid quote conflict

### DIFF
--- a/roles/run_awx_tests/tasks/main.yml
+++ b/roles/run_awx_tests/tasks/main.yml
@@ -65,7 +65,7 @@
 
     - name: Run the specified command
       shell: |
-        kubectl exec {{ pod_name }} -- bash -c '{{ "/entrypoint.sh " + (command | quote) }}'
+        kubectl exec {{ pod_name }} -- bash -c "{{ "/entrypoint.sh " + (command | quote) }}"
 
     - name: Copy artifacts to host
       shell: |


### PR DESCRIPTION
The schema differ job isn't working in AWX (and also not new job I'm trying to add). It runs:

```
kubectl exec awx-detect-schema-change-4701 -- bash -c '/entrypoint.sh '/start_tests.sh detect-schema-change''
```

This is trying to make this work correctly. The end result here is that `start_tests.sh` does not get any arguments, so it runs tests and doesn't detect schema change.