### PR TITLE
log-classify: update role with latest change

### DIFF
--- a/playbooks/base-minimal/post.yaml
+++ b/playbooks/base-minimal/post.yaml
@@ -21,9 +21,9 @@
     - block:
         - import_role: name=upload-log-classify-model
         - import_role: name=upload-logs
-        - import_role: name=emit-job-report
         - import_role: name=buildset-artifacts-location
       vars:
+        zuul_log_compress: true
         zuul_log_url: "https://ansible.softwarefactory-project.io/logs"
         zuul_logserver_root: /var/www/logs
 

--- a/roles/log-classify/defaults/main.yaml
+++ b/roles/log-classify/defaults/main.yaml
@@ -1,7 +1,5 @@
 # Set optin to False to disable log-classify
 logclassify_optin: True
-# Set report to True to hijack the reported log url
-logclassify_report: False
 
 # How many job logs to use for building the model
 logclassify_model_job_count: 2
@@ -27,6 +25,8 @@ logclassify_model_dir: "{{ logclassify_tmp_dir }}"
 
 # Process console-log
 logclassify_console: true
+# Process ara ansible.sqlite
+logclassify_ara_database: false
 
 # Include paths from baseline logs
 logclassify_logserver_dir: ""

--- a/roles/log-classify/tasks/run.yaml
+++ b/roles/log-classify/tasks/run.yaml
@@ -12,10 +12,6 @@
   set_fact:
     _model_path: "{{ logclassify_model_dir }}/{{ _model_name }}"
 
-- name: Set report name
-  set_fact:
-    _report_name: "{% if logclassify_report %}report{% else %}log-classify{% endif %}"
-
 - name: Create directories
   file:
     path: "{{ item }}"
@@ -49,6 +45,7 @@
       {% if logclassify_model_pipeline %}--pipeline {{ logclassify_model_pipeline }}{% endif %}
       --count {{ logclassify_model_job_count }}
       --zuul-web {{ logclassify_zuul_web }}
+      {% if logclassify_ara_database %}--ara-database {% endif %}
       {% if logclassify_logserver_dir %}--include-path {{ logclassify_logserver_dir }}{% endif %}
       {% for _path in logclassify_exclude_paths %}--exclude-path {{ _path }}{% endfor %}
       {% for _path in logclassify_exclude_files %}--exclude-file {{ _path }}{% endfor %}
@@ -73,22 +70,26 @@
       --after-context {{ logclassify_after_context }}
       {% if logclassify_local_dir != zuul.executor.log_root %}
         {# Running on test instance directly #}
-        {% if logclassify_console %}
-            {{ logclassify_tmp_dir }}/job-output.txt
-        {% endif %}
-        {% if logclassify_local_dir %}
+        {% if logclassify_ara_database %}
+            {{ logclassify_tmp_dir }}/ara-report/ansible.sqlite
+        {% elif logclassify_local_dir %}
             {{ logclassify_local_dir }}
             --test-prefix {{ logclassify_logserver_dir }}
+        {% else %}
+            {{ logclassify_tmp_dir }}/job-output.txt
         {% endif %}
       {% else %}
         {# Running on executor #}
-        {% if logclassify_logserver_dir %}
+        {% if logclassify_ara_database %}
+            {{ logclassify_local_dir }}/ara-report/ansible.sqlite
+        {% elif logclassify_logserver_dir %}
             {{ logclassify_local_dir }}
         {% else %}
             {{ logclassify_local_dir }}/job-output.txt
         {% endif %}
       {% endif %}
-      --html {{ logclassify_tmp_dir }}/{{ _report_name }}.html
+      --html {{ logclassify_tmp_dir }}/log-classify.html
+      --json {{ logclassify_tmp_dir }}/log-classify.json
       {% if logclassify_static_location %}--static-location {{ logclassify_static_location }}{% endif %}
       {% if logclassify_logserver_dir %}--include-path {{ logclassify_logserver_dir }}{% endif %}
       {% for _path in logclassify_exclude_paths %}--exclude-path {{ _path }}{% endfor %}
@@ -100,8 +101,8 @@
 
 - name: Fetch report
   synchronize:
-    src: "{{ logclassify_tmp_dir }}/{{ _report_name }}.{{ item }}"
-    dest: "{{ zuul.executor.log_root }}/{{ _report_name }}.{{ item }}"
+    src: "{{ logclassify_tmp_dir }}/log-classify.{{ item }}"
+    dest: "{{ zuul.executor.log_root }}/log-classify.{{ item }}"
     mode: pull
   with_items:
     - html
@@ -127,3 +128,15 @@
   when:
     - _model_check.rc == 4
     - _model_build.rc == 0
+
+- name: Return the report artifact
+  when:
+    - _model_check.rc == 0 or _model_build.rc == 0
+    - _model_run.rc == 0
+  delegate_to: localhost
+  zuul_return:
+    data:
+      zuul:
+        artifacts:
+          - name: "LogReduce report"
+            url: "log-classify.html"


### PR DESCRIPTION
This change updates the base job with latest changes:

- Use the new log-classify role
- Remove the deprecated emit-job-report
- Add the zuul_log_compress flag