### PR TITLE
gate: remove clean-check requirement

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -48,6 +48,7 @@
       http://docs.openstack.org/infra/manual/developers.html#automated-testing
     manager: dependent
     precedence: high
+    supercedes: check
     require:
       github.com:
         review:
@@ -56,7 +57,6 @@
             type: approved
         # Require label
         label: mergeit
-        status: "softwarefactory-project-zuul\\[bot\\]:ansible/check:success"
         open: True
         current-patchset: True
     trigger:


### PR DESCRIPTION
Clean-check means that gate does not start without a successful check.
Turns out that is a requirement that has been lifted from the openstack old days, and it we could remove it.
Accepting this change results in:

once you approve and add the gate-it tag, then check jobs are canceled and the change goes directly to gate.