### PR TITLE
ansible/zuul-jobs: disable unprocted branches for the zuul-jobs project

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -10,7 +10,8 @@ resources:
             zuul/exclude-unprotected-branches: true
 
         # Shared jobs
-        - ansible/zuul-jobs
+        - ansible/zuul-jobs:
+            zuul/exclude-unprotected-branches: true
 
         # Ansible projects
         - ansible/ansible:


### PR DESCRIPTION
This would prevent issue when unexpected dev branch are pushed
to the ansible/zuul-jobs project.

Before merging that change we need to make sure the master branch
of ansible/zuul-jobs is actually protected.