### PR TITLE
pushing awx schema was erroring on artifact copy

### DIFF
--- a/roles/run_awx_tests/tasks/main.yml
+++ b/roles/run_awx_tests/tasks/main.yml
@@ -69,7 +69,7 @@
 
     - name: Copy artifacts to host
       shell: |
-        kubectl cp {{ pod_name }}:{{ item }} {{ ansible_user_dir }}/{{ zuul.project.src_dir }}/
+        kubectl cp {{ pod_name }}:{{ item }} {{ ansible_user_dir }}/{{ zuul.project.src_dir }}/{{ item }}
       with_items: "{{ artifacts | default([]) }}"
 
   always:


### PR DESCRIPTION
* kubectl cp invoked with | was causing a newline to get added, causing
an error. This seems to be a behavior change in ansible-2.8 (didn't
happen in 2.7)
* This change explicitly specifies the destination in hopes to avoid the
error that is happening. Note that a newline will still be added
