### PR TITLE
correct s3 file upload src location

### DIFF
--- a/playbooks/awx-push-new-schema.yaml
+++ b/playbooks/awx-push-new-schema.yaml
@@ -10,7 +10,7 @@
       aws_s3:
         bucket: awx-public-ci-files
         object: schema.json
-        src: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/schema.json"
+        src: "/awx_devel/schema.json"
         mode: put
         permission: public-read
       environment:


### PR DESCRIPTION
* The task before this copies the schema artifact _out_ of the container
and onto the local machine. The s3 upload now references that local copy
rather than the container (which is running on a different machine)
copy.
