### PR TITLE
strip remote file dir info when copying local

### DIFF
--- a/roles/run_awx_tests/tasks/main.yml
+++ b/roles/run_awx_tests/tasks/main.yml
@@ -67,9 +67,9 @@
       shell: |
         kubectl exec {{ pod_name }} -- bash -c "{{ '/entrypoint.sh ' + (command | quote) }}"
 
+    # ansible > 2.7 seems to add a '\n' when shell: | is used in conjunction with kubectl cp
     - name: Copy artifacts to host
-      shell: |
-        kubectl cp {{ pod_name }}:{{ item }} {{ ansible_user_dir }}/{{ zuul.project.src_dir }}/{{ item }}
+      shell: kubectl cp {{ pod_name }}:{{ item }} {{ ansible_user_dir }}/{{ zuul.project.src_dir }}/{{ item | basename }}
       with_items: "{{ artifacts | default([]) }}"
 
   always:


### PR DESCRIPTION
* Was using the full path of the remote file when downloading locally.
i.e. "/foo/bar/file.txt" copied to "/meyers/" would result in
"/meyers/foo/bar/file.txt". Instead "/foo/bar/file.txt" copied to
"/meyers/" would result in "/meyers/file.txt"
