### PR TITLE
base: switch base nodeset to pod

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -43,7 +43,7 @@
     nodeset:
       nodes:
         - name: container
-          label: runc-fedora
+          label: pod-fedora-31
 
 - job:
     name: base


### PR DESCRIPTION
This change replaces the legacy runc node to the new
pod node to prevent NODE_FAILURE error.