### PR TITLE
jobs: add a base-openshift job to work for linter using pod-fedora

### DIFF
--- a/playbooks/base-openshift/post.yaml
+++ b/playbooks/base-openshift/post.yaml
@@ -1,0 +1,45 @@
+# This file is managed by ansible, do not edit directly
+---
+- hosts: all
+  tasks:
+    - block:
+        - include_role: name=fetch-output
+      when:
+        - "ansible_connection != 'kubectl'"
+        - ansible_user_dir is defined
+    - block:
+        - include_role: name=fetch-output-openshift
+      when:
+        - "ansible_connection == 'kubectl'"
+        - ansible_user_dir is defined
+    - import_role: name=merge-output-to-logs
+      when: ansible_user_dir is defined
+
+- hosts: localhost
+  roles:
+    - role: add-fileserver
+      fileserver: "{{ site_sflogs }}"
+    - role: generate-zuul-manifest
+    - role: ara-report
+      # This depends-on https://review.openstack.org/577675
+      ara_report_run: True
+      ara_report_type: database
+      ara_report_path: ara-report
+    - role: log-classify
+      logclassify_model_store_url: https://ansible.softwarefactory-project.io/logs/classifiers
+      logclassify_zuul_web: https://ansible.softwarefactory-project.io/zuul/api
+      logclassify_model_dir: /var/lib/log-classify
+      logclassify_local_dir: "{{ zuul.executor.log_root }}"
+
+- hosts: "{{ site_sflogs.fqdn }}"
+  gather_facts: false
+  tasks:
+    # Use a block because play vars doesn't take precedence on roles vars
+    - block:
+        - import_role: name=upload-log-classify-model
+        - import_role: name=upload-logs
+        - import_role: name=buildset-artifacts-location
+      vars:
+        zuul_log_compress: true
+        zuul_log_url: "https://ansible.softwarefactory-project.io/logs"
+        zuul_logserver_root: "/var/www/logs"

--- a/playbooks/base-openshift/pre.yaml
+++ b/playbooks/base-openshift/pre.yaml
@@ -1,0 +1,24 @@
+---
+- hosts: localhost
+  tasks:
+    - block:
+        - import_role: name=emit-job-header
+        # This depends-on https://review.openstack.org/578234
+        - import_role: name=log-inventory
+      vars:
+        zuul_log_url: "https://ansible.softwarefactory-project.io/logs"
+
+- hosts: all
+  tasks:
+    - block:
+        - include_role: name=validate-host
+        - include_role: name=prepare-workspace
+        - include_role: name=add-build-sshkey
+      when: "ansible_connection != 'kubectl'"
+    - block:
+        - include_role: name=prepare-workspace-openshift
+        - include_role: name=remove-zuul-sshkey
+      run_once: true
+      when: "ansible_connection == 'kubectl'"
+    - import_role: name=ensure-output-dirs
+      when: ansible_user_dir is defined

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -26,6 +26,26 @@
 # 6) Once the change in step 5 merges, abandon the change from step 4.
 
 - job:
+    name: base-openshift
+    parent: null
+    description: |
+      The base-openshift job for Ansible's installation of Zuul that works with kubectl.
+    pre-run: playbooks/base-openshift/pre.yaml
+    post-run:
+      - playbooks/base-openshift/post.yaml
+    roles:
+      - zuul: sf-jobs
+      - zuul: zuul/zuul-jobs
+    timeout: 1800
+    attempts: 3
+    secrets:
+      - site_ansiblelogs
+    nodeset:
+      nodes:
+        - name: container
+          label: pod-fedora-31
+
+- job:
     name: base-minimal
     parent: null
     description: |
@@ -93,11 +113,13 @@
     name: ansible/zuul-config
     check:
       jobs:
-        - linters
+        - linters:
+            parent: base-openshift
         - config-check
     gate:
       jobs:
-        - linters
+        - linters:
+            parent: base-openshift
         - config-check
     post:
       jobs:
@@ -108,10 +130,12 @@
     name: ansible/zuul-jobs
     check:
       jobs:
-        - linters
+        - linters:
+            parent: base-openshift
     gate:
       jobs:
-        - linters
+        - linters:
+            parent: base-openshift
 
 
 - job:


### PR DESCRIPTION
This change enables using pod-fedora node to run simple job like
the linters.