### PR TITLE
Add config-linters job

### DIFF
--- a/playbooks/linters.yaml
+++ b/playbooks/linters.yaml
@@ -1,0 +1,3 @@
+- hosts: all
+  roles:
+    - linters

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -109,17 +109,20 @@
     nodeset:
       nodes: []
 
+- job:
+    name: config-linters
+    parent: base-openshift
+    run: playbooks/linters.yaml
+
 - project:
     name: ansible/zuul-config
     check:
       jobs:
-        - linters:
-            parent: base-openshift
+        - config-linters
         - config-check
     gate:
       jobs:
-        - linters:
-            parent: base-openshift
+        - config-linters
         - config-check
     post:
       jobs:


### PR DESCRIPTION
This change adds a new config-linters job that would use the
new base job that works with kubectl node.