### PR TITLE
base-openshift: fix typo in logs secret

### DIFF
--- a/playbooks/base-openshift/post.yaml
+++ b/playbooks/base-openshift/post.yaml
@@ -18,7 +18,7 @@
 - hosts: localhost
   roles:
     - role: add-fileserver
-      fileserver: "{{ site_sflogs }}"
+      fileserver: "{{ site_ansiblelogs }}"
     - role: generate-zuul-manifest
     - role: ara-report
       # This depends-on https://review.openstack.org/577675
@@ -31,7 +31,7 @@
       logclassify_model_dir: /var/lib/log-classify
       logclassify_local_dir: "{{ zuul.executor.log_root }}"
 
-- hosts: "{{ site_sflogs.fqdn }}"
+- hosts: "{{ site_ansiblelogs.fqdn }}"
   gather_facts: false
   tasks:
     # Use a block because play vars doesn't take precedence on roles vars


### PR DESCRIPTION
This change fixes this issue:
  The error was: 'site_sflogs' is undefined