### PR TITLE
Remove old test config

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -17,6 +17,5 @@
               - awx-api-lint
               - awx-api
               - awx-ui
-              - awx-ui-next
               - awx-swagger
               - awx-ansible-modules


### PR DESCRIPTION
- We've removed the old ui code from devel. 
- There will now only be one zuul job for ui - `awx-ui`. 
- The `make` targets it uses are now running the tests for the new ui, so we can delete the `*-next` config