### PR TITLE
zuul-jobs: fix linters job name

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -128,18 +128,14 @@
       jobs:
         - config-update
 
-
 - project:
     name: ansible/zuul-jobs
     check:
       jobs:
-        - linters:
-            parent: base-openshift
+        - config-linters
     gate:
       jobs:
-        - linters:
-            parent: base-openshift
-
+        - config-linters
 
 - job:
     name: wait-for-changes-ahead


### PR DESCRIPTION
This change updates the default nodeset to f32.