### PR TITLE
zuul-jobs: remove the project definition

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -128,15 +128,6 @@
       jobs:
         - config-update
 
-- project:
-    name: ansible/zuul-jobs
-    check:
-      jobs:
-        - config-linters
-    gate:
-      jobs:
-        - config-linters
-
 - job:
     name: wait-for-changes-ahead
     parent: null


### PR DESCRIPTION
This is no longer necessary and this can be defined in the zuul-jobs project
directly.

Depends-On: https://github.com/ansible/zuul-jobs/pull/45