### PR TITLE
Update base post playbook hosts definition

### DIFF
--- a/playbooks/base-minimal/post.yaml
+++ b/playbooks/base-minimal/post.yaml
@@ -14,7 +14,7 @@
       logclassify_model_dir: /var/lib/log-classify
       logclassify_local_dir: "{{ zuul.executor.log_root }}"
 
-- hosts: "{{ site_ansiblelogs.fqdn }}"
+- hosts: "ansible.softwarefactory-project.io"
   gather_facts: false
   tasks:
     # Use a block because play vars doesn't take precedence on roles vars


### PR DESCRIPTION
This change fixes an issue where it is no longer possible to use
a secret attribute for hosts.