### PR TITLE
Revert "openshift: bump the base label to pod-fedora-33"

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -43,7 +43,7 @@
     nodeset:
       nodes:
         - name: container
-          label: pod-fedora-33
+          label: pod-fedora-31
 
 - job:
     name: base-minimal


### PR DESCRIPTION
This reverts commit dbf05371a4383b99fa53d2667ad65d45d114241c.
