### PR TITLE
ansible-zuul-jobs: exclude-unprotected-branches: false

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -8,7 +8,8 @@ resources:
         - ansible/zuul-config:
             zuul/config-project: True
             zuul/exclude-unprotected-branches: true
-        - ansible/ansible-zuul-jobs
+        - ansible/ansible-zuul-jobs:
+            zuul/exclude-unprotected-branches: false
         # Ansible projects
         - ansible/ansible:
             zuul/include: []


### PR DESCRIPTION
It's not clear why the job from the main branch are not imported. This
explicitly turns exclude-unprotected-branches off.
