### PR TITLE
vmware_rest: use sfa-collections-community-vmware-rest template

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -33,4 +33,4 @@
     name: ansible-collections/vmware.vmware_rest
     default-branch: main
     templates:
-      - ansible-collections-community-vmware-rest
+      - sfa-collections-community-vmware-rest


### PR DESCRIPTION
Use a different name for the templates coming from the main branch of
ansible-zuul-jobs.
