### PR TITLE
turn on exclude-unprotected-branches globally

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -3,6 +3,7 @@ resources:
     ansible:
       description: Ansible is an IT automation tool.
       tenant: ansible
+      zuul/exclude-unprotected-branches: true
       source-repositories:
         # The config projects
         - ansible/zuul-config:


### PR DESCRIPTION
Turn on `exclude-unprotected-branches` off by default for the whole
tenant.
