### PR TITLE
ansible-zuul-jobs: extra-config-paths zuul.sf.d/

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,6 +7,8 @@
 - project:
     name: goneri/ansible-zuul-jobs
     default-branch: main
+    extra-config-paths:
+      - zuul.sf.d/nodesets.yaml
 
 - project:
     name: ansible/ansible


### PR DESCRIPTION
We will use this directory to store the nodeset for SoftwareFactory. This
way we can maintain to different nodeset files in the same repository.
