### PR TITLE
ansible-zuul-jobs: extra-config-paths zuul.sf.d/nodesets.yaml

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -10,7 +10,7 @@ resources:
             zuul/exclude-unprotected-branches: true
         - goneri/ansible-zuul-jobs:
             zuul/exclude-unprotected-branches: true
-
+            zuul/extra-config-paths: [zuul.sf.d/*]
         - ansible-collections/amazon.aws:
             zuul/exclude-unprotected-branches: true
         - ansible-collections/cloud.common:


### PR DESCRIPTION
We will use this directory to store the nodeset for SoftwareFactory. This
way we can maintain to different nodeset files in the same repository.
