### PR TITLE
switch on ansible/ansible-zuul-jobs

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -10,6 +10,9 @@ resources:
             zuul/exclude-unprotected-branches: true
         - goneri/ansible-zuul-jobs:
             zuul/exclude-unprotected-branches: true
+            include: []
+        - ansible/ansible-zuul-jobs:
+            zuul/exclude-unprotected-branches: true
             zuul/extra-config-paths: [zuul.sf.d/*]
         - ansible-collections/amazon.aws:
             zuul/exclude-unprotected-branches: true


### PR DESCRIPTION
Now we've got the zuul.{ansible,sf}.d/ directores in place, we can use
the same configuration for the two platforms.
