### PR TITLE
define build-ansible-collection only one time

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -144,22 +144,6 @@
           label: ansible-fedora-35-1vcpu
 
 - job:
-    name: build-ansible-collection
-    description: |
-      Build ansible collections and return artifacts to zuul
-    pre-run: playbooks/build-ansible-collection/pre.yaml
-    run: playbooks/build-ansible-collection/run.yaml
-    post-run:
-      - playbooks/build-ansible-collection/post.yaml
-    required-projects:
-      - github.com/ansible-network/releases
-    nodeset:
-      nodes:
-        - name: controller
-          label: ansible-fedora-35-1vcpu
-
-
-- job:
     name: ansible-core-ci-aws-session
     description: |
       Create an AWS/sts session with an ansible-core-ci key.


### PR DESCRIPTION
build-ansible-collection was defined two times and this was
resulting in the pre-run been called two times in a row.
