### PR TITLE
run the publish jobs on the controller

### DIFF
--- a/playbooks/publish/ansible-automation-hub.yaml
+++ b/playbooks/publish/ansible-automation-hub.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: localhost
+- hosts: controller
   tasks:
     - name: Publish collections to Ansible Galaxy
       block:

--- a/playbooks/publish/ansible-galaxy.yaml
+++ b/playbooks/publish/ansible-galaxy.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: localhost
+- hosts: controller
   tasks:
     - name: Publish collections to Ansible Galaxy
       block:


### PR DESCRIPTION
With SoftwareFactory, there is no ansible-galaxy on the Zuul Executor:
/bin/sh: /opt/venv/zuul-ansible/2.9.16/bin/ansible-galaxy: No such file or directory
