### PR TITLE
upload-ansible-collection-fork: adjust the artifacts path

### DIFF
--- a/roles/upload-ansible-collection-fork/defaults/main.yaml
+++ b/roles/upload-ansible-collection-fork/defaults/main.yaml
@@ -1,4 +1,4 @@
 ---
-ansible_galaxy_collection_path: "{{ zuul.executor.log_root }}/artifacts"
+ansible_galaxy_collection_path: "~/artifacts"
 ansible_galaxy_executable: ansible-galaxy
 ansible_galaxy_type: galaxy


### PR DESCRIPTION
We run the role on the controller, the artifacts are in the ~/artifacts
directory.
