### PR TITLE
Revert "publish jobs: don't use post-run"

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -174,6 +174,7 @@
     run:
       - playbooks/ansible-collection/run-pre.yaml
       - playbooks/ansible-collection/run.yaml
+    post-run:
       - playbooks/ansible-collection/post.yaml
       - playbooks/publish/ansible-automation-hub.yaml
     required-projects:
@@ -211,6 +212,7 @@
     run:
       - playbooks/ansible-collection/run-pre.yaml
       - playbooks/ansible-collection/run.yaml
+    post-run:
       - playbooks/ansible-collection/post.yaml
       - playbooks/publish/ansible-galaxy.yaml
     required-projects:


### PR DESCRIPTION
This reverts commit 708a31d2b8dd64c21e350e787141405c526f5020.

```
The conditional check 'zuul_success | bool' failed. The error was: error while evaluating conditional (zuul_success | bool): 'zuul_success' is undefined

The error appears to be in '/var/lib/zuul/builds/f1a7636966e34e08b6d5ac92288865dc/trusted/project_0/github.com/ansible/zuul-config/playbooks/publish/ansible-galaxy.yaml': line 6, column 11, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

      block:
        - name: Run upload-ansible-collection-fork
          ^ here
```
