### PR TITLE
adjust the default-branch regex to include github.com/ prefix

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,7 +7,7 @@
       - system-required
 
 - project:
-    name: ^ansible-collections/.*
+    name: ^(github.com/|)ansible-collections/.*
     default-branch: main
 
 - project:


### PR DESCRIPTION
Sounds like this was not enough.

See: https://github.com/ansible/ansible-zuul-jobs/pull/1303#issuecomment-1014717991
