### PR TITLE
default-branch: put back the rules for the ansible-collections

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,4 +1,10 @@
 ---
+# NOTE(Gonéri): I'm not sure about this one, but it seems to help
+# when the project is not defined here.
+- project:
+    name: ^(github.com/|)ansible-collections/.*
+    default-branch: main
+
 - project:
     name: ansible/ansible-zuul-jobs
     default-branch: master


### PR DESCRIPTION
By removing this, we triggered this error:

```
ERROR Project github.com/ansible-collections/ansible.netcommon does not have the default branch master in 19s
```

See: https://github.com/ansible-collections/community.aws/pull/875
