### PR TITLE
Add project config to fix CI error

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -117,3 +117,9 @@
     default-branch: main
     templates:
       - system-required
+
+- project:
+    name: ansible-collections/ansible.utils
+    default-branch: main
+    templates:
+      - system-required


### PR DESCRIPTION
## Overview
Created this PR in a similar vein to this PR: https://github.com/ansible/zuul-config/pull/207
To try and fix this error in the CI:
https://github.com/ansible-collections/community.aws/pull/875#issuecomment-1016160880
```
build-ansible-collection : ERROR Project github.com/ansible-collections/ansible.utils does not have the default branch master in 16s
```