### PR TITLE
eos: remove the network-ee-container-image-jobs template

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -106,7 +106,6 @@
       - ansible-collections-arista-eos
       - ansible-collections-arista-eos-units
       - ansible-python-jobs
-      - network-ee-container-image-jobs
       - network-ee-tests
       - integrated-queue
       - publish-to-galaxy


### PR DESCRIPTION
We should not need these jobs when https://github.com/ansible/ansible-zuul-jobs/pull/1304
will be ready.
