### PR TITLE
build-ansible-collection: replace synchronize with fetch

### DIFF
--- a/playbooks/build-ansible-collection/post.yaml
+++ b/playbooks/build-ansible-collection/post.yaml
@@ -20,11 +20,10 @@
       delegate_to: localhost
 
     - name: Collect tarball artifacts
-      synchronize:
+      fetch:
         dest: "{{ zuul.executor.log_root }}/artifacts/"
-        mode: pull
         src: "{{ item.path }}"
-        verify_host: true
+        flat: true
       with_items: "{{ result.files }}"
 
     - name: Return collection artifacts to Zuul


### PR DESCRIPTION
We cannot use `synchronize` with a `kubevirt` connection:

```
msg": "synchronize uses rsync to function. rsync needs to connect to the remote host via ssh, docker client or a direct filesystem copy. This remote host is being accessed via kubectl instead so it cannot work."
```
