### PR TITLE
disable the buildset related jobs

### DIFF
--- a/zuul.d/jobs-ee.yaml
+++ b/zuul.d/jobs-ee.yaml
@@ -2,48 +2,20 @@
 - job:
     name: ansible-buildset-registry
     description: |
-      Starts a buildset registry which interacts with the intermediate
-      CI registry to share speculative container images between
-      projects.
-
-      Configure any jobs which require the use of a buildset registry
-      to depend on this job using the "dependencies" job attribute.
-
-      This job will pause after starting the registry so that it is
-      available to any jobs which depend on it.  Once all such jobs
-      are complete, this job will finish.
-    pre-run: playbooks/buildset-registry/pre.yaml
-    run: playbooks/buildset-registry/run.yaml
-    post-run: playbooks/buildset-registry/post.yaml
-    #nodeset: ubuntu-bionic-2vcpu
-    nodeset:
-      nodes:
-        - name: controller
-          label: ansible-fedora-35-1vcpu
-    vars:
-      container_command: docker
-    secrets:
-      - secret: ansible-intermediate-registry
-        name: intermediate_registry
+      Dummy job that do nothing.
+    pre-run: []
+    run: []
+    post-run: []
 
 - job:
     name: ansible-buildset-registry-consumer
     description: |
-      Pull from the intermediate registry
-
-      This is a parent for jobs which use container images and expect
-      a buildset registry to be running.  It pulls images from the
-      intermediate registry into it.
-    pre-run: playbooks/buildset-registry/pre.yaml
-    secrets:
-      - secret: ansible-intermediate-registry
-        name: intermediate_registry
+      Dummy job that do nothing.
+    pre-run: []
 
 - job:
     name: ansible-upload-container-image
     parent: ansible-build-container-image
     description: |
-      Build and upload a container image.
-    post-run: playbooks/container-image/upload.yaml
-    secrets:
-      - container_registry_credentials
+      Dummy job that do nothing.
+    post-run: []


### PR DESCRIPTION
We should not need these jobs once
https://github.com/ansible/ansible-zuul-jobs/pull/1304 is merged.
