### PR TITLE
disable the mirror until the problem with updates is resolved

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -13,9 +13,6 @@
     - include_role: name=start-zuul-console
     - when: ansible_connection != "kubectl"
       block:
-      - name: Enable the mirror
-        import_role:
-          name: use-our-mirror
       - name: Disable Fedora Modular
         file:
           path: /etc/yum.repos.d/fedora-modular.repo


### PR DESCRIPTION
e.g:

```
2022-01-21 17:13:22.009102 | TASK [Install git and tox]
2022-01-21 17:13:28.680739 | fedora-35 | ERROR
2022-01-21 17:13:28.681005 | fedora-35 | {
2022-01-21 17:13:28.681061 | fedora-35 |   "msg": "Failed to download metadata for repo 'updates': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried",
2022-01-21 17:13:28.681103 | fedora-35 |   "rc": 1,
2022-01-21 17:13:28.681141 | fedora-35 |   "results": []
2022-01-21 17:13:28.681178 | fedora-35 | }
```
