### PR TITLE
arista-eos: use the ansible-ee-tests template

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -106,7 +106,7 @@
       - ansible-collections-arista-eos
       - ansible-collections-arista-eos-units
       - ansible-python-jobs
-      - network-ee-tests
+      - ansible-ee-tests
       - integrated-queue
       - publish-to-galaxy
       - publish-to-automation-hub


### PR DESCRIPTION
The use the ansible-ee-tests template to run the EE jobs.
