### PR TITLE
eos: disable ansible-collections-arista-eos

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -103,7 +103,8 @@
     merge-mode: squash-merge
     templates:
       - system-required
-      - ansible-collections-arista-eos
+      # TODO: depends on network-ee-build-container-image
+      #- ansible-collections-arista-eos
       - ansible-collections-arista-eos-units
       - ansible-python-jobs
       - ansible-ee-tests


### PR DESCRIPTION
ansible-collections-arista-eos depends on network-ee-build-container-image
which we don't run.
