### PR TITLE
build-ansible-collection-pod: avoid ansible_user_dir

### DIFF
--- a/playbooks/build-ansible-collection-pod/run.yaml
+++ b/playbooks/build-ansible-collection-pod/run.yaml
@@ -13,14 +13,23 @@
       register: result
       ignore_errors: true
     - debug: var=result
+    - command: whoami
+      register: result
+      ignore_errors: true
+    - debug: var=result
+    - command: pwd
+      register: result
+      ignore_errors: true
+    - debug: var=result
+    - debug: var=zuul
 
     - name: Install generate-ansible-collection
-      command: "pip install --user {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
+      command: "pip install --user ~/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
 
     - name: Generate version number for ansible collection
       args:
-        chdir: "{{ ansible_user_dir }}/{{ item.src_dir }}"
-      shell: "if test -f 'galaxy.yml'; then {{ ansible_user_dir }}/.local/bin/generate-ansible-collection; fi"
+        chdir: "~/{{ item.src_dir }}"
+      shell: "if test -f 'galaxy.yml'; then ~/.local/bin/generate-ansible-collection; fi"
       with_items: "{{ zuul.projects.values() | list }}"
 
     - name: Run build-ansible-collection role
@@ -28,6 +37,6 @@
         name: build-ansible-collection
       vars:
         ansible_galaxy_executable: "/usr/bin/ansible-galaxy"
-        ansible_galaxy_output_path: "{{ ansible_user_dir }}/artifacts"
-        zuul_work_dir: "{{ ansible_user_dir }}/{{ item.src_dir }}"
+        ansible_galaxy_output_path: "~/artifacts"
+        zuul_work_dir: "~/{{ item.src_dir }}"
       with_items: "{{ zuul.projects.values() | list }}"


### PR DESCRIPTION
`ansible_user_dir` targets /root which does not exist in the container.
