### PR TITLE
build-ansible-collection-pod: avoid double /

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -31,8 +31,6 @@
       - include_role: name=prepare-workspace
     - include_role: name=prepare-workspace-openshift
       when: ansible_connection == "kubectl"
-    - debug:
-        var: zuul.resources
 
 - hosts: all:!appliance
   tasks:

--- a/playbooks/build-ansible-collection-pod/run.yaml
+++ b/playbooks/build-ansible-collection-pod/run.yaml
@@ -3,7 +3,7 @@
   vars:
     # With container, prepare-workspace-openshift copies the
     # src directory in /
-    ansible_user_dir: /
+    ansible_user_dir: ''
   tasks:
     - name: Install generate-ansible-collection
       command: "pip install --user {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"


### PR DESCRIPTION
This to avoid error like this one:
```
ERROR: Invalid requirement: '//src/github.com/ansible-network/releases'
```
