### PR TITLE
build-ansible-collection-pod: use zuul-output directory

### DIFF
--- a/playbooks/build-ansible-collection-pod/run.yaml
+++ b/playbooks/build-ansible-collection-pod/run.yaml
@@ -10,11 +10,16 @@
       shell: "if test -f 'galaxy.yml'; then ~/.local/bin/generate-ansible-collection; fi"
       with_items: "{{ zuul.projects.values() | list }}"
 
+    - name: Create a directory the zuul-output
+      file:
+        path: "{{ ansible_user_dir }}/zuul-output/artifacts"
+        state: directory
+
     - name: Run build-ansible-collection role
       include_role:
         name: build-ansible-collection
       vars:
         ansible_galaxy_executable: "/usr/bin/ansible-galaxy"
-        ansible_galaxy_output_path: "~/artifacts"
+        ansible_galaxy_output_path: "{{ ansible_user_dir }}/zuul-output/artifacts"
         zuul_work_dir: "~/{{ item.src_dir }}"
       with_items: "{{ zuul.projects.values() | list }}"


### PR DESCRIPTION
The zuul-output/artifacts files are automatically pulled by
fetch-output-openshift.
