### PR TITLE
build-ansible-collection-pod: looks for artifacts at the right place

### DIFF
--- a/playbooks/build-ansible-collection-pod/post.yaml
+++ b/playbooks/build-ansible-collection-pod/post.yaml
@@ -4,7 +4,7 @@
     - name: Find tarballs in folder
       find:
         file_type: file
-        paths: "~/artifacts"
+        paths: "{{ ansible_user_dir }}/zuul-output/artifacts"
         patterns: "*.tar.gz"
       register: result
 


### PR DESCRIPTION
The artifacts are now generated in "{{ ansible_user_dir }}/zuul-output/artifacts"
