### PR TITLE
Allow zuul configuration to be loaded from ara repos

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -85,12 +85,11 @@ resources:
             zuul/include: []
         - ansible-community/ansible-bender:
             zuul/include: []
-        - ansible-community/ara:
-            zuul/include: []
-        - ansible-community/ara-collection:
-            zuul/include: []
-        - ansible-community/ara-infra:
-            zuul/include: []
+        # ara job configuration is handled inside their own repositories
+        # reach out to dmsimard for questions or issues
+        - ansible-community/ara
+        - ansible-community/ara-collection
+        - ansible-community/ara-infra
         - ansible-community/molecule-libvirt:
             zuul/include: []
         - ansible-community/molecule-vagrant:


### PR DESCRIPTION
The ara job and pipeline configuration is inside their own repositories
so we need to not exclude it.