### PR TITLE
no publish-to-galaxy-3pci on c.aws and c.vmware

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -14,7 +14,7 @@
     default-branch: master
 
 - project:
-    name: ^(github.com/|)ansible-collections/community\..*
+    name: "^(github.com/|)ansible-collections/community.(?!aws|vmware).*"
     templates:
       - publish-to-galaxy-3pci
 


### PR DESCRIPTION
These collections already use `publish-to-galaxy`.
