### PR TITLE
Stop annoying comments on successful third-party-check runs

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -345,6 +345,7 @@
     success:
       github.com:
         status: 'success'
+        comment: false
       sqlreporter:
     failure:
       github.com:


### PR DESCRIPTION
These comments have been flooding community.general and other community collections since the softwarefactory-project.io Zuul has been added to them ([example](https://github.com/ansible-collections/community.docker/pull/293#issuecomment-1030696483)).