### PR TITLE
third-party-check pipeline: no report on failure too

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -350,6 +350,7 @@
     failure:
       github.com:
         status: 'failure'
+        comment: false
       sqlreporter:
     # Don't report merge-failures to github
     merge-failure:


### PR DESCRIPTION
The failures are alreadyl listed in the job results.
