### PR TITLE
twitter: use python3 -mvenv to prepare the venv

### DIFF
--- a/playbooks/ansible-collection/twitter.yaml
+++ b/playbooks/ansible-collection/twitter.yaml
@@ -2,7 +2,7 @@
 - hosts: localhost
   tasks:
     - name: Create virtualenv for ansible-network/releases
-      shell: virtualenv --python python3 ~/venv
+      shell: python3 -mvenv ~/venv
 
     - name: Bootstrap ansible-network/releases
       args:


### PR DESCRIPTION
Don't rely on the deprecated `virtualenv` command to prepare the
venv for `releases`.
