### PR TITLE
release-ansible-python: use -m venv to create venv

### DIFF
--- a/playbooks/publish/pypi.yaml
+++ b/playbooks/publish/pypi.yaml
@@ -4,7 +4,7 @@
     - name: Publish artifacts to pypi
       block:
         - name: Create virtualenv for twine
-          shell: virtualenv --python python3 ~/venv
+          shell: python3 -m venv ~/venv
 
         - name: Install twine into virtualenv
           shell: ~/venv/bin/pip install twine


### PR DESCRIPTION
virtualenv command is deprecated.
