### PR TITLE
plugin_builder: apply ansible-python-jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -179,6 +179,7 @@
       - system-required
       - integrated-queue
       - ansible-community-ansible-plugin-builder
+      - ansible-python-jobs
       - ansible-ee-tests
       - publish-to-galaxy
 


### PR DESCRIPTION
This is not supposed to work because of the lack of tox.ini file.
It's just to validate the project configuration. The change will
be revert later.
