### PR TITLE
base: ensure epel-release is enable on CentOS

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -21,6 +21,11 @@
           path: /etc/yum.repos.d/fedora-modular.repo
           state: absent
         become: true
+      - name: Enable EPEL
+        package:
+          name:
+            - epel-release
+        when: ansible_distribution == "CentOS"
       - name: Install git and tox
         package:
           name:


### PR DESCRIPTION
We need epel-release to download `python3-tox`.
