### PR TITLE
ansible-workshops-tox-integration: flatten the nodeset

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -304,5 +304,8 @@
     secrets:
       - secret: aws_workshops_secrets
         name: aws_workshops_data
-    nodeset: centos-8-stream
+    nodeset:
+      nodes:
+        - name: controller
+          label: ansible-cloud-centos-8-stream
     timeout: 5400


### PR DESCRIPTION
We cannot reuse yet the nodeset name defined in ansible-zuul-jobs.
This because we load a part of the configuration from
zuul.sf.d/nodesets.yaml too and this confuse Zuul.
