### PR TITLE
ansible.plugin_builder: remove some templates

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -179,8 +179,6 @@
       - system-required
       - integrated-queue
       - ansible-community-ansible-plugin-builder
-      - ansible-python-jobs
-      - ansible-ee-tests
       - publish-to-galaxy
 
 - project:


### PR DESCRIPTION
We don't need these templates anymore:

- ansible-python-jobs
- ansible-ee-tests
