### PR TITLE
network-ee: do not load local jobs

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -102,7 +102,7 @@ resources:
         - ansible/network:
             zuul/include: []
         - ansible/network-ee:
-            zuul/include: [job]
+            zuul/include: []
         - ansible-network/ansible_content_collections_metrics:
             zuul/include: []
         - ansible-network/arista_eos:


### PR DESCRIPTION
They will be defined directly in ansible-zuul-jobs when
https://github.com/ansible/ansible-zuul-jobs/pull/1398 is merged.
