### PR TITLE
ansible/workshop: update the node label

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -307,5 +307,5 @@
     nodeset:
       nodes:
         - name: controller
-          label: ansible-cloud-centos-8-stream
+          label: ansible-cloud-centos-8-stream-tiny
     timeout: 5400


### PR DESCRIPTION
ansible-cloud-centos-8-stream has been replaced by ansible-cloud-centos-8-stream-tiny.
