### PR TITLE
increase the number of retry to 6

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -39,7 +39,7 @@
     extra-vars:
       zuul_use_fetch_output: true
     timeout: 1800
-    attempts: 3
+    attempts: 6
     secrets:
       - site_ansiblelogs
       - rackspace_dfw_clouds_yaml


### PR DESCRIPTION
We hit `retry_limit` rather often, the problem may be resolved soon by the
platform upgrade.
