### PR TITLE
Disable ee and hub templates for amazon.cloud

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -51,9 +51,7 @@
     templates:
       - system-required
       - publish-to-galaxy
-      - publish-to-automation-hub
       - ansible-collections-amazon-cloud
-      - ansible-ee-tests
 
 - project:
     name: ansible-collections/amazon_cloud_code_generator


### PR DESCRIPTION
We don't need either of these right now.