### PR TITLE
enable EPEL on RHEL

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -36,6 +36,12 @@
           - name: Show the subscription-manager status
             command: subscription-manager status
             become: true
+          - name: Enable EPEL on RHEL
+            shell: |
+              major_version=$(echo $VERSION_ID|cut -d. -f1)
+              subscription-manager repos --enable codeready-builder-for-rhel-${major_version}-$(arch)-rpms
+              dnf install -f https://dl.fedoraproject.org/pub/epel/epel-release-latest-${major_version}.noarch.rpm
+            become: true
       - name: Install git and tox
         package:
           name:


### PR DESCRIPTION
python3-tox is not in EPEL. We may want to reconsider this in the future.
For now, this is good enough.
