### PR TITLE
downstream-ee: rename the playbook

### DIFF
--- a/playbooks/downstream-ee-integration/pre.yaml
+++ b/playbooks/downstream-ee-integration/pre.yaml
@@ -7,8 +7,8 @@
         state: present
       become: true
     - name: Login brew.registry.redhat.io
-      command: podman login --username {{ rhsm.login }} --password {{ rhsm.password|quote }} brew.registry.redhat.com
+      command: "podman login --username {{ rhsm.login }} --password '{{ rhsm.password }}' brew.registry.redhat.com"
       no_log: true
     - name: Login registry.redhat.io
-      command: podman login --username {{ rhsm.login }} --password {{ rhsm.password|quote }} registry.redhat.com
+      command: "podman login --username {{ rhsm.login }} --password '{{ rhsm.password }}' registry.redhat.com"
       no_log: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -317,7 +317,7 @@
     description: |
       Base job to run the EE integration tests
     pre-run:
-      - playbooks/downstream-ee/pre.yaml
+      - playbooks/downstream-ee-integration/pre.yaml
       - playbooks/ansible-core-ci/pre.yaml
     secrets:
       - rhsm


### PR DESCRIPTION
- rename the playbook
- use static quote to protect the password, the previous solution with the
  `quote` filter seems to be broken.
