### PR TITLE
release-ansible-collection: point TMPDIR on a FS tmp dir

### DIFF
--- a/roles/release-ansible-collection/tasks/main.yml
+++ b/roles/release-ansible-collection/tasks/main.yml
@@ -8,4 +8,6 @@
   shell: "{{ ansible_prepare_release__playbook_executable }} {{ ansible_prepare_release__playbook_path }} -v"
   args:
     chdir: "{{ ansible_prepare_release__collection_path }}"
+  environment:
+    TMPDIR: /var/tmp/prepare-release
   when: _result.stat.exists


### PR DESCRIPTION
/tmp is a RAM FS, we can exhauste the free space if we use it to store
large amount of data.
