### PR TITLE
vmware_rest_code_generator: don't include ansible-python3-jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -147,7 +147,6 @@
     name: ansible-collections/vmware_rest_code_generator
     default-branch: main
     templates:
-      - ansible-python3-jobs
       - ansible-collections-community-vmware-rest-code-generator
       - integrated-vmware-queue
     check:


### PR DESCRIPTION
ansible-python3-jobs pull ansible-toxpy36 which we don't want to run.
