### PR TITLE
Disable PyPI releases for builder/runner

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -338,7 +338,6 @@
     merge-mode: squash-merge
     templates:
       - system-required
-      - publish-to-pypi
 
 - project:
     name: ansible/ansible-core-image
@@ -358,7 +357,6 @@
     merge-mode: squash-merge
     templates:
       - system-required
-      - publish-to-pypi
 
 - project:
     name: ansible/network


### PR DESCRIPTION
We are moving away from using Zuul for releasing to PyPI.