### PR TITLE
enable publish-to-galaxy-3pci for hetzner.hcloud

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -27,6 +27,11 @@
       - publish-to-galaxy-3pci
 
 - project:
+    name: ansible-collections/hetzner.hcloud
+    templates:
+      - publish-to-galaxy-3pci
+
+- project:
     name: ansible/ansible-zuul-jobs
     default-branch: master
     merge-mode: squash-merge


### PR DESCRIPTION
As requested on Matrix by resmo.
