### PR TITLE
Remove community.azure

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -167,8 +167,6 @@ resources:
             zuul/include: []
         - ansible-collections/ansible.windows:
             zuul/include: []
-        - ansible-collections/community.azure:
-            zuul/include: []
         - ansible-collections/community.cassandra:
             zuul/include: []
         - ansible-collections/community.ciscosmb:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -6,10 +6,6 @@
     default-branch: main
 
 - project:
-    name: ansible-collections/community.azure
-    default-branch: master
-
-- project:
     name: ansible-collections/community.cassandra
     default-branch: master
 


### PR DESCRIPTION
Since community.azure 2.0.0 the collection is a dead shell that will no longer be released or built.

CC @Andersson007