### PR TITLE
community.nextcloud: Add publishing on Galaxy by Zuul

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -63,6 +63,8 @@ resources:
             zuul/include: []
         - ansible-collections/community.aws:
             zuul/include: []
+        - ansible-collections/community.nextcloud:
+            zuul/include: []
         - ansible-collections/community.vmware:
             zuul/include: []
         - ansible-collections/community.yang:


### PR DESCRIPTION
As README looks a bit outdated I created the [issue](https://github.com/ansible/zuul-config/issues/425) to avoid questions like the following in future:
Is it enough what i did here to enable publishing on Galaxy by Zuul or I need to do something else?
Thanks