### PR TITLE
community.arduino: Add publishing on Galaxy by Zuul

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -59,6 +59,8 @@ resources:
             zuul/include: []
         - ansible-collections/cloud.common:
             zuul/include: []
+        - ansible-collections/community.arduino:
+            zuul/include: []
         - ansible-collections/community.asa:
             zuul/include: []
         - ansible-collections/community.aws:


### PR DESCRIPTION
community.arduino: Add publishing on Galaxy by Zuul
relates to https://github.com/ansible/community/issues/587 and https://github.com/ansible-community/community-team/issues/37