### PR TITLE
Revert "amazon.aws: temporarily use the merge strategy"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -48,7 +48,7 @@
 - project:
     name: ansible-collections/amazon.aws
     default-branch: main
-    merge-mode: merge
+    merge-mode: squash-merge
     templates:
       - system-required
       - publish-to-galaxy


### PR DESCRIPTION
https://github.com/ansible-collections/amazon.aws/pull/997 is now merged.

This reverts commit 4ab3356b9ada86aa4b62b61ee40f68a3d70d249a.
