### PR TITLE
Revert "amazon.aws: temporarily use the merge strategy"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -48,7 +48,7 @@
 - project:
     name: ansible-collections/amazon.aws
     default-branch: main
-    merge-mode: merge
+    merge-mode: squash-merge
     templates:
       - system-required
       - publish-to-galaxy


### PR DESCRIPTION
This reverts commit 166da1c483820b3ca4736b46b00a6883d150889f.
