### PR TITLE
amazon.aws: temporarily use the merge strategy

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -48,7 +48,7 @@
 - project:
     name: ansible-collections/amazon.aws
     default-branch: main
-    merge-mode: squash-merge
+    merge-mode: merge
     templates:
       - system-required
       - publish-to-galaxy


### PR DESCRIPTION
We've got a last promotiom PR to merge.
