### PR TITLE
Revert "amazon.aws: temporarily use the merge strategy"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -48,7 +48,7 @@
 - project:
     name: ansible-collections/amazon.aws
     default-branch: main
-    merge-mode: merge
+    merge-mode: squash-merge
     templates:
       - system-required
       - publish-to-galaxy


### PR DESCRIPTION
This reverts commit c24250d2711b354aca3c5e73d326e98cc2fb3b30.
