### PR TITLE
Enable zuul actions for ansible-collections/ansible.snmp

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -121,8 +121,6 @@ resources:
             zuul/include: []
         - ansible/network-ee:
             zuul/include: []
-        - ansible-network/ansible.snmp:
-            zuul/include: []
         - ansible-network/ansible_content_collections_metrics:
             zuul/include: []
         - ansible-network/config_manager:
@@ -176,6 +174,8 @@ resources:
         - ansible/ansible:
             zuul/include: []
         - ansible-community/collection_migration:
+            zuul/include: []
+        - ansible-collections/ansible.snmp:
             zuul/include: []
         - ansible-collections/ansible.windows:
             zuul/include: []

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -16,8 +16,6 @@
 - project:
     name: ^(github.com/|)ansible-network/.*
     default-branch: main
-    templates:
-      - publish-to-galaxy-3pci
 
 - project:
     name: ^(github.com/|)(ansible-collections|sap-linuxlab)/community\..*
@@ -25,7 +23,7 @@
       - publish-to-galaxy-3pci
 
 - project:
-    name: ansible-network/ansible.snmp
+    name: ansible-collections/ansible.snmp
     templates:
       - publish-to-automation-hub
 


### PR DESCRIPTION
- add ansible-collections/ansible.snmp to resource/ansible (removes ansible-network) reference
- disable publish-to-galaxy-3pci on the ansible-network collection (to earlier state)
- apply publish-to-automation-hub template to ansible.snmp (fix repo reference)

reverts fixes PRs as collection migrated from ansible-network to ansible-collections
https://github.com/ansible/zuul-config/pull/450
https://github.com/ansible/zuul-config/pull/451
https://github.com/ansible/zuul-config/pull/452