### PR TITLE
Restore the release jobs for ansible.utils

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -200,6 +200,14 @@
       - publish-to-automation-hub
 
 - project:
+    name: ansible-collections/ansible.utils
+    default-branch: main
+    templates:
+      - system-required
+      - publish-to-galaxy
+      - publish-to-automation-hub
+
+- project:
     name: github.com/ansible-collections/checkpoint
     merge-mode: squash-merge
     templates:


### PR DESCRIPTION
I think this should do the job while we figure out how to make the release elsewhere.