### PR TITLE
ansible/ansible-zuul-jobs: ignore zuul.sf.d/ directory

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -8,9 +8,7 @@ resources:
         - ansible/zuul-config:
             zuul/config-project: True
             zuul/exclude-unprotected-branches: False
-        - ansible/ansible-zuul-jobs:
-            zuul/extra-config-paths: [zuul.sf.d/]
-
+        - ansible/ansible-zuul-jobs
         - ansible/ansible-builder:
             zuul/include: []
         - ansible/ansible-core-image:


### PR DESCRIPTION
The migration is done, no need to source this directory.
