### PR TITLE
Revert "a.aws: apply the ansible-collections-amazon-aws-each-target template"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -59,7 +59,6 @@
       - publish-to-galaxy
       - publish-to-automation-hub
       - ansible-collections-amazon-aws
-      - ansible-collections-amazon-aws-each-target
 
 - project:
     name: ansible-collections/amazon.cloud


### PR DESCRIPTION
Something is wrong with this change, the project configuration is not updated.
See: https://github.com/ansible/ansible-zuul-jobs/pull/1672

This reverts commit 39d0a4865cad03500bde0582da10f91a62031342.
