### PR TITLE
Remove deprecated option from pipelines.yaml

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -336,4 +336,4 @@
         status: 'failure'
         comment: false
     # Don't report merge-failures to github
-    merge-failure: {}
+    merge-conflict: {}


### PR DESCRIPTION
The option merge-failure was removed from zuul. Use the new merge-conflict keyword to fix:

extra keys not allowed @ data['merge-failure']