### PR TITLE
Remove ansible-collections-kubernetes-core-units

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -256,7 +256,6 @@
     merge-mode: squash-merge
     templates:
       - system-required
-      - ansible-collections-kubernetes-core-units
       - publish-to-galaxy
       - publish-to-automation-hub
 


### PR DESCRIPTION
Summary:

Moved ansible-collections/kubernetes.core unit test to GHA. So removing the corresponding template from zuul-config.