### PR TITLE
Remove ansible-collections-amazon-aws unit job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -62,7 +62,6 @@
     templates:
       - publish-to-galaxy
       - publish-to-automation-hub
-      - ansible-collections-amazon-aws
       - ansible-collections-amazon-aws-each-target
       - ansible-collections-amazon-aws-integration
 


### PR DESCRIPTION
ansible-collections-amazon-aws unit jobs are migrated to Github Actions. Hence removing the template from zuul-config.