### PR TITLE
Remove cloud.aws_ops template

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -619,14 +619,6 @@
       - ansible-collections-cloud-aws_troubleshooting
 
 - project:
-    name: ansible-collections/cloud.aws_ops
-    default-branch: main
-    merge-mode: squash-merge
-    templates:
-      - system-required
-      - ansible-collections-cloud-aws_ops
-
-- project:
     name: github.com/ansible-collections/cloud.terraform
     default-branch: main
     merge-mode: squash-merge


### PR DESCRIPTION
The testing has been migrated to GHA from zuul.