### PR TITLE
Remove aws_troubleshooting project

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -611,14 +611,6 @@
 
 
 - project:
-    name: ansible-collections/cloud.aws_troubleshooting
-    default-branch: main
-    merge-mode: squash-merge
-    templates:
-      - system-required
-      - ansible-collections-cloud-aws_troubleshooting
-
-- project:
     name: ansible-collections/cloud.aws_ops
     default-branch: main
     merge-mode: squash-merge


### PR DESCRIPTION
The jobs are moved to GHA. So removing the project from zuul.