### PR TITLE
Remove amazon.cloud job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -72,7 +72,6 @@
     templates:
       - system-required
       - publish-to-galaxy
-      - ansible-collections-amazon-cloud
 
 - project:
     name: ansible-collections/amazon_cloud_code_generator


### PR DESCRIPTION
amazon.cloud sanity and unit jobs are moved to GitHub Action