### PR TITLE
Remove reference to kubernetes.core collection

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -83,8 +83,6 @@ resources:
             zuul/include: []
         - ansible-collections/junipernetworks.junos:
             zuul/include: []
-        - ansible-collections/kubernetes.core:
-            zuul/include: []
         - ansible-collections/openvswitch.openvswitch:
             zuul/include: []
         - ansible-collections/osbuild.composer:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -241,15 +241,6 @@
         - ansible-tox-linters
 
 - project:
-    name: github.com/ansible-collections/kubernetes.core
-    default-branch: main
-    merge-mode: squash-merge
-    templates:
-      - system-required
-      - publish-to-galaxy
-      - publish-to-automation-hub
-
-- project:
     name: github.com/openshift/community.okd
     default-branch: main
     merge-mode: squash-merge


### PR DESCRIPTION
Before being merged, required secrets to push to automation-hub and galaxy-hub should be created on kubernetes.core repository first