### PR TITLE
Remove cloud.terraform

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -55,8 +55,6 @@ resources:
             zuul/include: []
         - ansible-collections/cloud.common:
             zuul/include: []
-        - ansible-collections/cloud.terraform:
-            zuul/include: []
         - ansible-collections/community.arduino:
             zuul/include: []
         - ansible-collections/community.asa:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -599,13 +599,3 @@
     default-branch: main
     templates:
       - publish-to-galaxy
-
-
-- project:
-    name: github.com/ansible-collections/cloud.terraform
-    default-branch: main
-    merge-mode: squash-merge
-    templates:
-      - system-required
-      - publish-to-galaxy
-      - publish-to-automation-hub

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -599,3 +599,11 @@
     default-branch: main
     templates:
       - publish-to-galaxy
+
+
+- project:
+    name: github.com/ansible-collections/cloud.terraform
+    default-branch: main
+    merge-mode: squash-merge
+    templates:
+      - system-required

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -599,11 +599,3 @@
     default-branch: main
     templates:
       - publish-to-galaxy
-
-
-- project:
-    name: github.com/ansible-collections/cloud.terraform
-    default-branch: main
-    merge-mode: squash-merge
-    templates:
-      - system-required


### PR DESCRIPTION
Before being merged, required secrets to push to automation-hub and galaxy-hub should be created on `ansible-collections/cloud.terraform` repository first