### PR TITLE
Remove ansible-tox-linters for cloud.common

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -110,7 +110,6 @@
     templates:
       - system-required
       - ansible-collections-cloud-common
-      - ansible-python-jobs
       - publish-to-galaxy
       - publish-to-automation-hub
 


### PR DESCRIPTION
This job has been migrated into GHA, therefore we do need Zuul to run it anymore.

ansible-python-jobs consists in `ansible-tox-linters` job only, more details here https://github.com/ansible/ansible-zuul-jobs/blob/94cae8b1a66775e122df3bd68ca45be757ba1ff7/zuul.d/project-templates.yaml#L17-L26