### PR TITLE
Add missing SAP collection

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -255,6 +255,8 @@ resources:
             zuul/include: []
         - sap-linuxlab/community.sap_libs:
             zuul/include: []
+        - sap-linuxlab/community.sap_launchpad:
+            zuul/include: []
         - ansible-collections/community.sops:
             zuul/include: []
         - ansible-collections/community.windows:


### PR DESCRIPTION
Corrects oversight when the other Ansible Collections for SAP (sap_install, sap_operations, sap_libs) were added to zuul-config