### PR TITLE
Re-encrypt galaxy token and disable validity check

### DIFF
--- a/playbooks/validate-ansible-galaxy-token/run.yaml
+++ b/playbooks/validate-ansible-galaxy-token/run.yaml
@@ -3,4 +3,6 @@
   tasks:
     - name: Validate the token
       no_log: true
-      shell: 'curl --header "Authorization: Token {{ ansible_galaxy_info.token }}" https://galaxy.ansible.com/api/internal/me/preferences/|grep notify_survey'
+      debug:
+        msg: "Skipping validation check"
+#      shell: 'curl --header "Authorization: Token {{ ansible_galaxy_info.token }}" https://galaxy.ansible.com/api/internal/me/preferences/|grep notify_survey'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -226,18 +226,19 @@
           label: ansible-fedora-37-1vcpu
     semaphore: ansible-automation-hub
 
-- job:
-    name: validate-ansible-galaxy-token
-    description: |
-      A job that validate the status of the Galaxy token
-    final: true
-    run:
-      - playbooks/validate-ansible-galaxy-token/run.yaml
-    secrets:
-      - secret: galaxy_secret
-        name: ansible_galaxy_info
-    nodeset:
-      nodes: []
+# We can not run this job until we determine a new endpoint that can be checked with galaxy-ng
+#- job:
+#    name: validate-ansible-galaxy-token
+#    description: |
+#      A job that validate the status of the Galaxy token
+#    final: true
+#    run:
+#      - playbooks/validate-ansible-galaxy-token/run.yaml
+#    secrets:
+#      - secret: galaxy_secret
+#        name: ansible_galaxy_info
+#    nodeset:
+#      nodes: []
 
 - job:
     name: release-ansible-collection-galaxy

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -227,18 +227,19 @@
     semaphore: ansible-automation-hub
 
 # We can not run this job until we determine a new endpoint that can be checked with galaxy-ng
-#- job:
-#    name: validate-ansible-galaxy-token
-#    description: |
-#      A job that validate the status of the Galaxy token
-#    final: true
-#    run:
-#      - playbooks/validate-ansible-galaxy-token/run.yaml
-#    secrets:
-#      - secret: galaxy_secret
-#        name: ansible_galaxy_info
-#    nodeset:
-#      nodes: []
+# For now, the playbook just prints a "skipping job" message.
+- job:
+    name: validate-ansible-galaxy-token
+    description: |
+      A job that validate the status of the Galaxy token
+    final: true
+    run:
+      - playbooks/validate-ansible-galaxy-token/run.yaml
+    secrets:
+      - secret: galaxy_secret
+        name: ansible_galaxy_info
+    nodeset:
+      nodes: []
 
 - job:
     name: release-ansible-collection-galaxy

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -3451,17 +3451,16 @@
     data:
       url: https://galaxy.ansible.com/
       token: !encrypted/pkcs1-oaep
-        - JKQ7hdqBldP9elk3hHAkaXdjAoCpJ9sv7C1wJnYJkDfnl7FbVZJ65YhqSAoCPikxst8oV
-          TAEKBbjRByWyJsBzEsjdw/iaXILBqICN8M5X/GFY1BMYnoU1X/GizXu4dKJNCmGqSaY+o
-          UdE2TrXy3MbZmTPMFe5pCBU180Nx1+jpR5JpyoTvG0x+V5kGUfYj6ZxJwBXOlCamNb9/P
-          RjsgNb0192qpVs5dJ5N+tAD9QF8h4G+xTOcuNAZu/3utxT8qGxh14I6yxU4xFBUeLYbEJ
-          hRQ2mfWQVLvXgM9phH5XPHzM+HWDEcxSZ/DPc8sjgoZdCb5EDibsejfiZNiA5BI/wJcYc
-          XQlvAHu8+XbUgF7/jICAPOkkAjH4PsLzFT5zcCV3GBMZKMl+tCiX7eOR52pmafz76ruec
-          sP/2OhBwBbO3My167cV04c1nHOlyBFPW8oWY8xCfMGut4Q49TpU+dDiHFSHWjxM7/XYrY
-          Xr1x2yPV1k9CIItULjVygVO3DNgo0KzB4j63FDA2Ml+8E13MRTMCZYljSdZGxvQ1bxWYl
-          0V9l0pCW8PlXZdSJSV9zu8qDZOoyYoVgtqt8Dc6zWgHuv0Nwb7/gEqk+z7Nzib5GJrEPg
-          +mKjl58HuL3THTr2B4JpK46d0j/RmTGd2r+IrMCngoZddTV4O5v7iChzuFDtRU=
-
+        - AX1p45ekqTlMSkSn/BcOi+qNd5poWdj7voqn4dgCr91YCmr5dbOfozrKYAimk4+Izfnw6
+          OeQru9JsefkY2IeUoIiLn5ZDOa9ChW794GuSZQ++vea8cq2zW6pI4eFRfMob1txqg9zgq
+          EtOev+1BPUuoKDjxRgwTgXvHhVdL/+jOxcodgjAyHF1+nT3zpLrexMokUpI5OgL+K7URh
+          Cm1B7Bf1mi6EfIIDCvmSDM2MXcjxr1Hqr64M025Vq/SWq+Y/6OV/e2or/lR7VA1rFy4lC
+          Ia51rb+J2RfnXe2KLFOW1ZPiHX7lTlhJlBDPtXxfHhRFDkuu3zPBKFvvIOJDE9Sfahfzx
+          AALEE3PFRix1csIDQXi97eKFdrsXiNWyd214F3wprjzag93JT281aK+e1bhQu5wxlLsBX
+          b/JSm5DGHqJnwEbwj3mJhZOvsp65mUU0+ilCWvOY4fBeTxRkdk/AECc/KwJktioJpfD7i
+          kdZ9GNH8VmMG03nsdPYG97vR8af+/qbVSYQI0xWcJy244OjrqrKCq0jnrJDS3H00THi9y
+          yNeZlGGjlZz/iLRTdPzAqlHnQuMIeGFn9gzCJZGm52oHzd+XT26mKwGhAomBI8UypNMDN
+          wh563fiXSAwgmtBoBeOtvFZIcrVHI9ukZCadbz+B93SD4EUULe6ZNURBuBkoUs=
 
 ####ansible_automation_hub_secret####
 


### PR DESCRIPTION
The API we were using to validate tokens no longer exists and no suitable replacement is immediately obvious.  Disable this check for now.

Collection uploads are still failing, despite the token working from the cli, so re-encrypt the Galaxy token and refresh.

Because we can't run the token validate job however, we don't have any real way to test this without someone actually doing a collection release.