### PR TITLE
Remove ansible-collections-cloud-common

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -109,7 +109,6 @@
     merge-mode: squash-merge
     templates:
       - system-required
-      - ansible-collections-cloud-common
       - publish-to-galaxy
       - publish-to-automation-hub
 


### PR DESCRIPTION
Remove ansible-collections-cloud-common, as the jobs have been migrated to GHA.