### PR TITLE
Stop running units on ansible.posix, that testing has moved to Azure Pipelines

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -271,7 +271,6 @@
     default-branch: main
     templates:
       - system-required
-      - ansible-collections-ansible-posix-units
       - publish-to-galaxy
       - publish-to-automation-hub
 


### PR DESCRIPTION
Stop running units on ansible.posix, that testing has moved to Azure Pipelines