### PR TITLE
Add publish-to-automation-hub for validated content cloud repos

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -607,3 +607,32 @@
       - publish-to-galaxy
       - publish-to-automation-hub
 
+- project:
+    name: redhat-cop/cloud.aws_ops
+    default-branch: main
+    templates:
+      - publish-to-automation-hub
+
+- project:
+    name: redhat-cop/cloud.aws_troubleshooting
+    default-branch: main
+    templates:
+      - publish-to-automation-hub
+
+- project:
+    name: redhat-cop/cloud.azure_ops
+    default-branch: main
+    templates:
+      - publish-to-automation-hub
+
+- project:
+    name: redhat-cop/cloud.gcp_ops
+    default-branch: main
+    templates:
+      - publish-to-automation-hub
+
+- project:
+    name: redhat-cop/cloud.terraform_ops
+    default-branch: main
+    templates:
+      - publish-to-automation-hub


### PR DESCRIPTION
Depends-On: #545 
Refer: https://issues.redhat.com/browse/ACA-1295

This PR adds the `publish-to-automation-hub` job to the validated content cloud repos.