### PR TITLE
Use publish-to-galaxy-plain for collections in ansible-collections/community.*, with explicit list of exceptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,8 @@ PR2
 
 note: You don't need to do it if the project satisfies the rules specified in the file. For example, `rule 1 <https://github.com/ansible/zuul-config/blob/master/zuul.d/projects.yaml#L4-L6>`_ and `rule 2 <https://github.com/ansible/zuul-config/blob/master/zuul.d/projects.yaml#L20-L23>`_ say that if a collection's repository name starts with ansible-collections/community* or sap-linux/community* and the repository has the `main` branch as default, the repository will be included in the project and published by Zuul on Galaxy automatically when a git tag is created in the collection's repo. In this case, only PR1 above is required.
 
+note: In case you have a ``community.*`` collection in the github.com/ansible-collections/ organization, you need to add your collection to the explicit regular expression that enables the ``publish-to-galaxy-3pci`` template if you do not have an equivalent of the Galaxy importer test running in GHA.
+
 
 Gating
 ======

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -22,9 +22,22 @@
     default-branch: main
 
 - project:
-    name: ^(github.com/|)(ansible-collections|sap-linuxlab|openshift)/community\..*
+    name: ^(github.com/|)(sap-linuxlab|openshift)/community\..*
     templates:
       - publish-to-galaxy-3pci
+
+- project:
+    # The negative lookahead excludes collections that use the template publish-to-galaxy-plain (see below)
+    name: ^(github.com/|)ansible-collections/community\.(?!crypto|dns|docker|general|hrobot|internal_test_tools|library_inventory_filtering|routeros|sops).*
+    templates:
+      - publish-to-galaxy-3pci
+
+- project:
+    # These projects use the shared workflow from https://github.com/ansible-community/github-action-test-galaxy-import
+    # so they don't need the rather slow third-party-check in CI
+    name: ^(github.com/|)ansible-collections/community\.(crypto|dns|docker|general|hrobot|internal_test_tools|library_inventory_filtering|routeros|sops)
+    templates:
+      - publish-to-galaxy-plain
 
 - project:
     name: ansible-collections/ansible.snmp
@@ -499,13 +512,6 @@
       - system-required
       - publish-to-galaxy
       - publish-to-automation-hub
-
-- project:
-    # These projects use the shared workflow from https://github.com/ansible-community/github-action-test-galaxy-import
-    # so they don't need the rather slow third-party-check in CI
-    name: ^(github.com/|)ansible-collections/community\.(crypto|dns|docker|general|hrobot|internal_test_tools|library_inventory_filtering|routeros|sops)
-    templates:
-      - publish-to-galaxy-plain
 
 - project:
     name: ansible-collections/servicenow.itsm

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -27,17 +27,17 @@
       - publish-to-galaxy-3pci
 
 - project:
-    # The negative lookahead excludes collections that use the template publish-to-galaxy-plain (see below)
-    name: ^(github.com/|)ansible-collections/community\.(?!crypto|dns|docker|general|hrobot|internal_test_tools|library_inventory_filtering|routeros|sops).*
-    templates:
-      - publish-to-galaxy-3pci
-
-- project:
-    # These projects use the shared workflow from https://github.com/ansible-community/github-action-test-galaxy-import
-    # so they don't need the rather slow third-party-check in CI
-    name: ^(github.com/|)ansible-collections/community\.(crypto|dns|docker|general|hrobot|internal_test_tools|library_inventory_filtering|routeros|sops)
+    # All projects **not** using the shared workflow from https://github.com/ansible-community/github-action-test-galaxy-import
+    # or something equivalent should be explicitly listed below!
+    name: ^(github.com/|)ansible-collections/community\..*
     templates:
       - publish-to-galaxy-plain
+
+- project:
+    # Lists all community.* collections in github.com/ansible-collections that do **not** use a GHA version of the Galaxy importer test.
+    name: ^(github.com/|)ansible-collections/community\.(arduino|asa|aws|cassandra|cip|ciscosmb|clickhouse|cockroachdb|digitalocean|elastic|fortios|fqcn_migration|google|grafana|hashi_vault|healthchecksio|ioscm|kubevirt|libvirt|molecule|mongodb|mysql|network|nextcloud|osbuild|pacemaker|postgresql|proxmox|proxysql|rabbitmq|sap|sonic|vagrant|vmware|windows|yang|zabbix)
+    templates:
+      - publish-to-galaxy-3pci
 
 - project:
     name: ansible-collections/ansible.snmp


### PR DESCRIPTION
Make sure that only the `publish-to-galaxy-plain` template (https://github.com/felixfontein/ansible-zuul-jobs/commit/0495329eda10728e0928c990992ab21021a27f70) is used for the set of collections, instead of Zuul merging both the `publish-to-galaxy-plain` and `publish-to-galaxy-3pci` templates for them.