### PR TITLE
Add job template to publish redhat.openshift on automation hub

### DIFF
--- a/playbooks/redhat-openshift/pre.yaml
+++ b/playbooks/redhat-openshift/pre.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: controller
+  tasks:
+    - name: Ensure make is installed on the controller
+      package:
+        name: make
+        state: present
+      become: true

--- a/playbooks/redhat-openshift/run.yaml
+++ b/playbooks/redhat-openshift/run.yaml
@@ -6,6 +6,14 @@
         chdir: "{{ zuul.project.src_dir }}"
       shell: "make downstream-build"
 
+    - name: Find tarballs to upload
+      find:
+        paths: "{{ zuul.project.src_dir }}"
+        patterns: "redhat-openshift-*.tar.gz"
+      register: found_tarballs
+
+    - debug: var=found_tarballs
+
     - name: Publish collections to Automation Hub
       block:
         - name: Run upload-ansible-collection-fork
@@ -14,3 +22,4 @@
           vars:
             ansible_galaxy_type: automation_hub
             ansible_galaxy_collection_path: "{{ zuul.project.src_dir }}"
+            ansible_galaxy_collection_tarballs: "{{ found_tarballs }}"

--- a/playbooks/redhat-openshift/run.yaml
+++ b/playbooks/redhat-openshift/run.yaml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+  tasks:
+    - name: Build downstream collection
+      args:
+        chdir: "{{ zuul.project.src_dir }}"
+      shell: "make downstream-build"
+
+    - name: Publish collections to Automation Hub
+      block:
+        - name: Run upload-ansible-collection-fork
+          include_role:
+            name: upload-ansible-collection-fork
+          vars:
+            ansible_galaxy_type: automation_hub
+            ansible_galaxy_collection_path: "{{ zuul.project.src_dir }}"

--- a/roles/upload-ansible-collection-fork/tasks/main.yaml
+++ b/roles/upload-ansible-collection-fork/tasks/main.yaml
@@ -17,13 +17,16 @@
       find:
         paths: "{{ ansible_galaxy_collection_path }}"
         patterns: "*.tar.gz"
-      register: found_tarballs
+      register: ansible_galaxy_collection_tarballs
+      when: ansible_galaxy_collection_tarballs is undefined
+
+    - debug: var=ansible_galaxy_collection_tarballs
 
     - name: Publish collection to Ansible Galaxy / Automation Hub
       environment:
         ANSIBLE_CONFIG: "{{ _ansiblecfg_tmp.path }}"
       shell: "{{ ansible_galaxy_executable }} -vvv collection publish {{ item.path }}"
-      with_items: "{{ found_tarballs.files }}"
+      with_items: "{{ ansible_galaxy_collection_tarballs.files }}"
 
   always:
     - name: Shred ansible-galaxy credentials

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -308,3 +308,25 @@
     secrets:
       - rhsm
       - ansible_core_ci
+
+- job:
+    name: release-redhat-openshift-automation-hub
+    description: |
+      Release downstream collection redhat.openshift to https://cloud.redhat.com/ansible/automation-hub
+    pre-run:
+      - playbooks/redhat-openshift/pre.yaml
+      - playbooks/ansible-collection/pre.yaml
+    run:
+      - playbooks/ansible-collection/run-pre.yaml
+      - playbooks/redhat-openshift/run.yaml
+    required-projects:
+      - github.com/ansible-network/releases
+    vars:
+      ansible_galaxy_executable: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/generate_collection_version/bin/ansible-galaxy"
+    secrets:
+      - secret: ansible_automation_hub_secret
+        name: ansible_galaxy_info
+    nodeset:
+      nodes:
+        - name: controller
+          label: ansible-fedora-37-1vcpu

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -241,6 +241,12 @@
     merge-mode: squash-merge
     templates:
       - ansible-collections-community-okd
+    pre-release:
+      jobs:
+        - release-redhat-openshift-automation-hub
+    release:
+      jobs:
+        - release-redhat-openshift-automation-hub
 
 - project:
     name: github.com/ansible-network/network-engine


### PR DESCRIPTION
`redhat.openshift` downstream collection needs to be published from `community.okd` repository therefore we can not use existing template.
This new job template adds the possibility to build and publish `redhat.openshift` collection to automation