### PR TITLE
Update the config-check managesf resource path

### DIFF
--- a/playbooks/config/check.yaml
+++ b/playbooks/config/check.yaml
@@ -69,7 +69,7 @@
       no_log: true
 
     - name: Check resources changes
-      shell: managesf-resources remote-validate --remote-gateway {{ gateway_url }}
+      shell: /usr/local/bin/managesf-resources remote-validate --remote-gateway {{ gateway_url }}
       args:
         chdir: "{{ config_root }}"
 


### PR DESCRIPTION
This change fixes the managesf-resources location on RHEL9.