### PR TITLE
Fix pipeline configuration error

### DIFF
--- a/playbooks/config/check.yaml
+++ b/playbooks/config/check.yaml
@@ -178,7 +178,7 @@
 
         - name: Validate zuul config syntax
           command: >
-            env - /usr/local/bin/zuul -c zuul.conf tenant-conf-check
+            env - /usr/local/bin/zuul-admin -c zuul.conf tenant-conf-check
           args:
             chdir: "{{ config_root }}/build"
 

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -58,16 +58,19 @@
       github.com:
         - event: pull_request_review
           action: submitted
-          state: approved
+          state:
+            - approved
         - event: pull_request
           action: comment
           comment: (?i)^\s*regate\s*$
         - event: pull_request_review
           action: submitted
-          state: approved
+          state:
+            - approved
         - event: pull_request_review
           action: dismissed
-          state: request_changes
+          state:
+            - changes_requested
         - event: pull_request
           action: status
           status: "softwarefactory-project-zuul\\[bot\\]:ansible/check:success"


### PR DESCRIPTION
Fix the following error 

```
The trigger configuration as supplied has an error: expected a list for dictionary value @ data['state']
```

Please refer to the configuration here is the source code
https://opendev.org/zuul/zuul/src/commit/b39a5cae99eb108da426d8d02cc8a17f895c468f/zuul/driver/github/githubtrigger.py#L139-L215