### PR TITLE
Update hostname for site_tenant_update

### DIFF
--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -120,7 +120,7 @@
 - secret:
     name: site_tenant_update
     data:
-      fqdn: softwarefactory-project.io
+      fqdn: managesf.softwarefactory-project.io
       ssh_known_hosts: managesf.softwarefactory-project.io ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDH1S8cBGX18okor8IEm8OKv/RuOurYoT5TU7dZegY43otEfMJeK1Jh4HgJHTXHr/yghj7SV4Nj8+wj5zM83RX51TDnRfgbvOGbadCmoEeP5tF2Hh7bBz9KVYh9f9pd8vrcT0QkLVJQzTcCHXOVYD7rU+/nDxlB+SFftH8+bXhkm1Jg3YtAE5yQrMKSVQmHCi8lBRMGMniCvEsxKvAapNVNTonF+KQk3XEBC1Y+pYuwRpO3HckMntzBK6Mlo/5M1wlzLPGg0JQ8UQsie6xm79jxGltwJZBpOPJ7lPPMaLFN0WYOVLLLHOtv8ZDIuPgT94MC1otb/+lfkQc0rVCa5M/nwsj0YI7V7dgp6FnNdRkAv+k2AgGvV7TDqIYDaGvvk3En/E/1xyU+0lq0XcOvG9NqBDrst07siMMbccwoPbgAVIAujbKDBdIkDsEWEAw9ShVIa+nm98n1zYavuNRZpqRxkUZsEhnCkyQkGoR+VvV0vNI+9y5KHGQf0QFzf97raPc=
       ssh_username: root
       ssh_private_key: !encrypted/pkcs1-oaep


### PR DESCRIPTION
This changes the hostname of the update server to match the hostname in the known_hosts entry.

I think this may fix the current issue with the config update failing (https://ansible.softwarefactory-project.io/zuul/build/d3f69faa81e64b4aa429564eda1b693c/log/job-output.txt#270).

The host key was changed about six months ago in https://github.com/ansible/zuul-config/commit/cb56036fc2b1f36189e7fd10d6b37de6344d3e4c. The `fqdn` variable is used in https://github.com/ansible/zuul-config/blob/0d4cd448372907f08b3c692f55f01bb2e75d6bd2/playbooks/config/update_tenant.yaml#L33-L36 and I think this needs to match the hostname in the known_hosts entry. I don't know why this wouldn't have been a problem until now.