### PR TITLE
Revert "Try and force config update"

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -5,7 +5,6 @@ resources:
       tenant: ansible
       source-repositories:
         # The config projects
-        #
         - ansible/zuul-config:
             zuul/config-project: True
             zuul/exclude-unprotected-branches: False


### PR DESCRIPTION
The config update is correctly working now after #582 but the tenant update never happened (https://ansible.softwarefactory-project.io/zuul/build/957938387d794aa29e9d3845ba63b7fe/log/job-output.txt#269). This is preventing #580 from being merged. I think the problem is because of https://github.com/ansible/zuul-config/blob/a32c955bd6beb6a88a6f2bffcc405583c1da634f/playbooks/config/update_tenant.yaml#L40

The update block has not been successfully run since the recent changes to `resources/ansible.yaml`. I think just changing this file should make the tenant update happen. This undoes my previous attempt to get things working.

This reverts commit be5bddd92089e04469d3dbc519aa61fe77880eba.