### PR TITLE
DNM - Publish on automation hub using Service account credentials

### DIFF
--- a/playbooks/refresh-automation-hub-token/run.yaml
+++ b/playbooks/refresh-automation-hub-token/run.yaml
@@ -1,6 +1,0 @@
----
-- hosts: localhost
-  tasks:
-    - name: Refresh offline token
-      no_log: true
-      shell: "curl https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token -d grant_type=refresh_token -d client_id=cloud-services -d refresh_token=\"{{ ansible_galaxy_info.token }}\" --fail --silent --show-error --output /dev/null"

--- a/roles/upload-ansible-collection-fork/templates/automation_hub.cfg.j2
+++ b/roles/upload-ansible-collection-fork/templates/automation_hub.cfg.j2
@@ -4,4 +4,5 @@ server_list = automation_hub
 [galaxy_server.automation_hub]
 url = https://cloud.redhat.com/api/automation-hub/
 auth_url = https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-token = {{ ansible_galaxy_info.token }}
+client_id = {{ ansible_galaxy_info.client_id }}
+client_secret = {{ ansible_galaxy_info.client_secret }}

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -188,20 +188,6 @@
       release_poetry_project: true
 
 - job:
-    name: refresh-automation-hub-token
-    description: |
-      Nightly job to refresh our offline token for automation hub
-
-      See https://access.redhat.com/articles/3626371 for expire information.
-    final: true
-    run: playbooks/refresh-automation-hub-token/run.yaml
-    secrets:
-      - secret: ansible_automation_hub_secret
-        name: ansible_galaxy_info
-    nodeset:
-      nodes: []
-
-- job:
     name: release-ansible-collection-automation-hub
     description: |
       Release ansible collection to https://cloud.redhat.com/ansible/automation-hub

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -177,11 +177,9 @@
     default-branch: master
     check:
       jobs:
-        - refresh-automation-hub-token
         - validate-ansible-galaxy-token
     periodic:
       jobs:
-        - refresh-automation-hub-token
         - validate-ansible-galaxy-token
 
 - project:


### PR DESCRIPTION
- The job have been prepared in order to support new secret defined as Service account with `client_id` and `client_secret`
- `ansible-galaxy` needs to be released with the following PR https://github.com/ansible/ansible/pull/83145
- We need to create a Service account with the required permissions and update the following secret ``ansible_automation_hub_secret``