### PR TITLE
add vmware_rest back into config for other projects

### DIFF
--- a/resources/ansible.yaml
+++ b/resources/ansible.yaml
@@ -301,3 +301,7 @@ resources:
         - redhat-cop/infra.platform_configuration:
             connection: github.com-git
             zuul/include: []
+        # vmware_rest does not use zuul, but other repos are dependent
+        # on it being in the zuul config
+        - ansible-collections/vmware.vmware_rest:
+            zuul/include: []


### PR DESCRIPTION
After seeing the other failures that are happening in community.vmware and https://github.com/ansible/ansible-zuul-jobs/pull/1892, I think its best to add these back in