### PR TITLE
fix issue with collection publishing

### DIFF
--- a/roles/upload-ansible-collection-fork/tasks/publish-collection-with-ansible-devel.yml
+++ b/roles/upload-ansible-collection-fork/tasks/publish-collection-with-ansible-devel.yml
@@ -1,10 +1,4 @@
 ---
-- name: Run our-ensure-python role
-  include_role:
-    name: our-ensure-python
-  vars:
-    ensure_python__version: "3.11"
-
 - name: Run ensure-virtualenv role
   include_role:
     name: ensure-virtualenv
@@ -18,7 +12,7 @@
 - block:
     - name: Create virtualenv and install ansible devel into it
       ansible.builtin.pip:
-        virtualenv_python: python3.12
+        virtualenv_python: python3.11
         virtualenv: "{{ venv_path.path }}"
         state: present
         name:


### PR DESCRIPTION
Remove call to `our-ensure-python` which needs `sudo`. The `sudo` was revoked in a previous step `playbook/ansible-collection/pre.yml` calling `revoke-sudo` role