### PR TITLE
add configuration for ansible.mcp project

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -469,9 +469,3 @@
 - project:
     name: ansible-collections/vmware_rest_code_generator
     default-branch: main
-
-- project:
-    name: ansible-collections/ansible.mcp
-    default-branch: main
-    templates:
-      - ansible-collections-ansible-mcp-integration


### PR DESCRIPTION
Refers to https://issues.redhat.com/browse/ACA-3510
Configure Zuul on repository `ansible-collections/ansible.mcp` to run integration tests