### PR TITLE
Add publishing pipelines to mcp collection

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -474,4 +474,6 @@
     name: ansible-collections/ansible.mcp
     default-branch: main
     templates:
+      - publish-to-galaxy
+      - publish-to-automation-hub
       - ansible-collections-ansible-mcp-integration


### PR DESCRIPTION
Add galaxy and AH publishing to ansible.mcp collection.