### PR TITLE
Update aws test provider  endpoint url

### DIFF
--- a/roles/ansible-core-ci-session/tasks/main.yaml
+++ b/roles/ansible-core-ci-session/tasks/main.yaml
@@ -10,7 +10,7 @@
     method: PUT
     body_format: json
     body: '{"config": {"platform": "aws", "version": "sts"}, "auth": {"remote": {"key": "{{ create_core_ci_session_key }}", "nonce": null}}, "threshold": 1}'
-    url: "https://ansible-core-ci.testing.ansible.com/{{ create_core_ci_session_stage }}/aws/{{ create_core_ci_instance_id }}"
+    url: "https://api.ci.core.ansible.com/{{ create_core_ci_session_stage }}/aws/{{ create_core_ci_instance_id }}"
     dest: "{{ create_core_ci_local_target_file }}"
     mode: '0400'
   no_log: true


### PR DESCRIPTION
Fixes #620 . 

The ansible-core-ci service has moved to a new AWS account and has a new domain name for accessing the service. The previous endpoint will be retired at some point in the future, so all existing users should update to use the new endpoint.