### PR TITLE
Restore ansible-collections-community-aws template

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -152,6 +152,7 @@
     templates:
       - system-required
       - publish-to-galaxy
+      - ansible-collections-community-aws
 
 - project:
     name: ansible/zuul-config


### PR DESCRIPTION
## Summary

Commit e9b010c accidentally removed the `ansible-collections-community-aws` template when removing integration test templates. This template is still required for ansible-galaxy-importer jobs as it sets amazon.aws as a dependency for community.aws testing.

## Changes

- Restores `ansible-collections-community-aws` template to the community.aws project configuration in `zuul.d/projects.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)