### PR TITLE
Allow optional leading v in release/pre-release tag triggers

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -112,7 +112,7 @@
     trigger:
       github.com:
         - event: push
-          ref: ^refs/tags/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)|((?:[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))$
+          ref: ^refs/tags/v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)|((?:[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))$
     failure:
       smtp:
         from: "ansible-zuul@redhat.com"
@@ -128,7 +128,7 @@
     trigger:
       github.com:
         - event: push
-          ref: ^refs/tags/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
+          ref: ^refs/tags/v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
     failure:
       smtp:
         from: "ansible-zuul@redhat.com"


### PR DESCRIPTION
## Summary
- Update the `release` and `pre-release` pipeline tag regexes in `zuul.d/pipelines.yaml` to accept an optional leading `v`.
- Network collections tag releases as `vX.Y.Z` (e.g. `v8.6.0`), while other teams often use `X.Y.Z`. The previous regex only matched tags without `v`, so pushing `v8.6.0` on ansible.netcommon did not trigger `publish-to-galaxy` / `publish-to-automation-hub`.

## Change
```diff
- ref: ^refs/tags/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
+ ref: ^refs/tags/v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
```

Same `v?` addition applied to the `pre-release` pipeline regex.

This remains compatible with existing tags that omit the `v` prefix.

## Context
Follow-up to network collections Zuul onboarding ([#648](https://github.com/ansible/zuul-config/pull/648), [#650](https://github.com/ansible/zuul-config/pull/650)). Suggested by @mhuin after diagnosing why ansible.netcommon tag pushes did not enter the release pipeline.

## Test plan
- [ ] Zuul config validates / config-update succeeds
- [ ] After merge, pushing a `vX.Y.Z` tag on a network collection (e.g. ansible.netcommon) triggers the release pipeline
- [ ] Tags without `v` (`X.Y.Z`) still trigger the release pipeline as before