### PR TITLE
feat(logging): add S3 as primary log upload target with Swift failover

### DIFF
--- a/playbooks/base/post.yaml
+++ b/playbooks/base/post.yaml
@@ -33,13 +33,10 @@
       vars:
         zuul_log_path_shard_build: true
 
-    - name: Build log upload targets and run failover (Swift only, to rule out failover config issues)
+    - name: Build log upload targets and run failover (S3 first, then Swift)
       block:
-        - name: Set zuul_log_targets (Swift with random Rackspace region)
+        - name: Set swift_target (Swift with random Rackspace region)
           ansible.builtin.set_fact:
-            targets: "{{ swift_target }}"
-          no_log: true
-          vars:
             swift_target:
               - target: swift
                 args:
@@ -47,10 +44,28 @@
                   zuul_log_container: ansible
                   zuul_log_cloud_config: "{{ item }}"
                   zuul_log_delete_after: 7776000
+          no_log: true
           with_random_choice:
             - "{{ rackspace_dfw_clouds_yaml }}"
             - "{{ rackspace_iad_clouds_yaml }}"
             - "{{ rackspace_ord_clouds_yaml }}"
+
+        - name: Set s3_target
+          ansible.builtin.set_fact:
+            s3_target:
+              - target: s3
+                args:
+                  zuul_log_partition: true
+                  zuul_log_bucket: zuul-logging
+                  zuul_log_bucket_public: true
+                  zuul_log_aws_access_key: "{{ zuul_logs_aws_s3.access_key_id }}"
+                  zuul_log_aws_secret_key: "{{ zuul_logs_aws_s3.secret_access_key }}"
+          no_log: true
+
+        - name: Set zuul_log_targets (S3 first, then Swift)
+          ansible.builtin.set_fact:
+            targets: "{{ s3_target + swift_target }}"
+          no_log: true
 
         - name: Run upload-logs-failover role (S3 then Swift)
           no_log: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -44,6 +44,7 @@
       - rackspace_dfw_clouds_yaml
       - rackspace_iad_clouds_yaml
       - rackspace_ord_clouds_yaml
+      - zuul_logs_aws_s3
       - rhsm
     nodeset:
       nodes:

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -3660,6 +3660,34 @@
       auth: *rackspace_auth
       region_name: ORD
 
+####aws_s3_bucket####
+
+- secret:
+    name: zuul_logs_aws_s3
+    data:
+      access_key_id: !encrypted/pkcs1-oaep
+        - EP0UuKywGKNZgHdKmOViuIpZAJEoLKTszJOgRwvZ4sXL2O1/2N86anHMqXLPUTX9A7q7z
+          SJymK4PCq7XJoV1SNqXXTsyCQ7w7RSftxQ8UWchEEsudTQXM6Td7qUANxkL9qP/pxAzW2
+          8mNH8gDE8Zpw9RLqmZd0KlWbpbamKEp8YNV5AWBE27/bfFMhSVKQPShGnzAUk3vYd5E+h
+          X0UzoczWDthh5pMssd03U7BjyeQcibssttJoE5jWQ9yrGlppSAmxwwdiAdjpNvgZ6UssL
+          rkEzi0PW03FPEDVJwq3/SQ3MLKto81d0XI7Ubidw1xd5HfyqKzcOza2FcHkNpL6l/Vbc0
+          B9vQTgBUAcA3Ff1bXyUHyQEpLyNFZGQ40isiCNwWb5Ejy+7NAWoGXfWC2kBarHwNSKhSQ
+          +5irggbNgyalqaZ5/aoePT5JMdJpgQ5a84E8HOA2VbcqD9uIESpEF4Ml7cj03k600SNQM
+          HLsKCKUCZiKJMluRNFyvgzhwrxjKXt8xPcGP2TyIO6WZ2Rihdu6kNtLTdlAmIBrV51JCm
+          HI4ytRrVUgVwjr8cqv+itS357wC1xCiPNsdESkPFCTv86W8BZuxl00IE6lQIT5iQqqXra
+          p4mIqEzJD7YuP41mcXafNClBYaxLs21J5nHstUM1T+itNxt4Z/mmPsXFK3n3/s=
+      secret_access_key: !encrypted/pkcs1-oaep
+        - nQYU/GBmBgueR6ceNHyqj4a+YBXUZ7zhS5Rbi3iZmniGCVJgeMamTlAtP7GKP8XwiId68
+          Wpd1R/HQy/MKGmWBET9u2EuhLCeZCOgsgQu/sXj2DVBVKHlvbkxmntiJHdmkzAOx+If5g
+          QN3B6PWUG2MUG94kiEhTNYOFnYUBrdBffbkvgUiA2qq7ATciT6jgflNvCU1yDFASrm8z5
+          IIwGah49FonTs68Ed46h6vvvn2y/9ZTaY3+dNWcU9i5K46Nwe+xRXc35PxYdj0KNtfPYc
+          lqeOeU6Gmi/UpyoNS9OLt6MOr5GESGWZmWxbU8JiMF/mW4+VGLQ+WJ5sEjsG7cXaBkdPt
+          qcz6OSevnWndavaQBOw2tlOboItanpwAYTR1YUWUTJRuiAbtlG718G4W+Ng/XncoBA6Ao
+          jq97n5SZsE/IcDB6RTQwXeohjwA31SQcBU5SUNWwn3qe9oHIU9nZlegbKYl7fmkISIUXT
+          mWcANMDKkWhxGURqyGca2GQrxgmRxws1rt5FLMpAM9hmcC8LMSt+tTHsIwrJ+90UzLA3/
+          VN6/g1jwXB19W1E/ecIF1TAxwGeuueNDJz3Y9nXiGT4X03WzTaqRf/nzyT5M3U/s7uEXU
+          PAUaDNDBwxpQMHvzU7Pp7njhnPNKm9VFimmrKLZcPV/MhrHFw5ppe2qwhAhSqg=
+          
 ####container_registry_credentials####
 
 - secret:


### PR DESCRIPTION
:warning: This work has a precedented history of breaking logging for Zuul for everyone, please be extra careful! 

Routes Zuul build logs to a public S3 bucket (zuul-logging) first, falling back to the existing Rackspace Swift target if S3 uploads fail. Since the base job is shared across multiple teams, failover order preserves upload availability. I suspect eventually we will remove Swift altogether, but that is for a later PR, once I'm sure S3 logging will work.

Hopefully fixes ACA-4966 :crossed_fingers:

Once this gets merged, we will need to check for Zuul failures pretty immediately and roll back if necessary. Historically, we've liked to do this by creating a DNM test in amazon.aws - https://github.com/ansible-collections/amazon.aws/pull/2848


Doc ref:
https://zuul-ci.org/docs/zuul-jobs/latest/log-roles.html#role-upload-logs-s3
https://zuul-ci.org/docs/zuul-jobs/latest/log-roles.html#role-upload-logs-failover


Claude Sonnet 5 did assist with this and I had it quadruple-check syntactical pieces.